### PR TITLE
Mac os

### DIFF
--- a/lib/sockutils.c
+++ b/lib/sockutils.c
@@ -345,7 +345,12 @@ gftp_fd_set_sockblocking (gftp_request * request, int fd, int non_blocking)
   else
     flags &= ~O_NONBLOCK;
 
+#ifdef __APPLE__
+  int opt = 1;
+  if (ioctl(fd, FIONBIO, &opt) < 0)
+#else
   if (fcntl (fd, F_SETFL, flags) < 0)
+#endif
     {
       request->logging_function (gftp_logging_error, request,
                                  _("Cannot set socket to non-blocking: %s\n"),

--- a/src/gtk/gftp-gtk.c
+++ b/src/gtk/gftp-gtk.c
@@ -1072,6 +1072,9 @@ CreateFTPWindows (GtkWidget * ui)
   gtk_paned_pack2 (GTK_PANED (logpane), log_table, 1, 1);
   gtk_box_pack_start (GTK_BOX (mainvbox), logpane, TRUE, TRUE, 0);
 
+  gtk_container_set_border_width (GTK_CONTAINER (transfer_scroll), 5);
+  gtk_container_set_border_width (GTK_CONTAINER (tempwid), 5);
+
   gtk_widget_show_all (mainvbox);
   gftpui_show_or_hide_command ();
   return (mainvbox);


### PR DESCRIPTION
c2d0acc is simply an attempt to make the log window more aesthetically pleasing by providing a border on the frame.

718e2a6 is more of a pain as without this patch, my sftp connections only work one out of a few dozen times. I've not been able to track down what is causing the buggy behavior on macOS, but I am assuming it is a platform bug as it is not 100% consistent.