### PR TITLE
Remove usage of all deprecated glib thread functions.

### DIFF
--- a/lib/gftp.h
+++ b/lib/gftp.h
@@ -545,8 +545,8 @@ typedef struct gftp_transfer_tag
   void * fromwdata,
        * towdata;
 
-  GStaticMutex statmutex,
-               structmutex;
+  GMutex statmutex,
+         structmutex;
 
   void *user_data;
   void *thread_id;

--- a/lib/misc.c
+++ b/lib/misc.c
@@ -554,8 +554,8 @@ gftp_tdata_new (void)
   tdata->statmutex = init_mutex;
   tdata->structmutex = init_mutex;
 #else
-  g_static_mutex_init (&tdata->statmutex);
-  g_static_mutex_init (&tdata->structmutex);
+  g_mutex_init (&tdata->statmutex);
+  g_mutex_init (&tdata->structmutex);
 #endif
 
   return (tdata);

--- a/lib/protocols.c
+++ b/lib/protocols.c
@@ -1433,7 +1433,7 @@ gftp_calc_kbs (gftp_transfer * tdata, ssize_t num_read)
   gftp_lookup_request_option (tdata->fromreq, "maxkbs", &maxkbs.f);
 
   if (g_thread_supported ())
-    g_static_mutex_lock (&tdata->statmutex);
+    g_mutex_lock (&tdata->statmutex);
 
   gettimeofday (&tv, NULL);
 
@@ -1456,13 +1456,13 @@ gftp_calc_kbs (gftp_transfer * tdata, ssize_t num_read)
       if (waitusecs > 0)
         {
           if (g_thread_supported ())
-            g_static_mutex_unlock (&tdata->statmutex);
+            g_mutex_unlock (&tdata->statmutex);
 
           waited = 1;
           usleep (waitusecs);
 
           if (g_thread_supported ())
-            g_static_mutex_lock (&tdata->statmutex);
+            g_mutex_lock (&tdata->statmutex);
         }
 
     }
@@ -1473,7 +1473,7 @@ gftp_calc_kbs (gftp_transfer * tdata, ssize_t num_read)
     memcpy (&tdata->lasttime, &tv, sizeof (tdata->lasttime));
 
   if (g_thread_supported ())
-    g_static_mutex_unlock (&tdata->statmutex);
+    g_mutex_unlock (&tdata->statmutex);
 }
 
 
@@ -1500,12 +1500,12 @@ gftp_get_transfer_status (gftp_transfer * tdata, ssize_t num_read)
   gftp_lookup_request_option (tdata->fromreq, "sleep_time", &sleep_time);
 
   if (g_thread_supported ())
-    g_static_mutex_lock (&tdata->structmutex);
+    g_mutex_lock (&tdata->structmutex);
 
   if (tdata->curfle == NULL)
     {
       if (g_thread_supported ())
-        g_static_mutex_unlock (&tdata->structmutex);
+        g_mutex_unlock (&tdata->structmutex);
 
       return (GFTP_EFATAL);
     }
@@ -1513,7 +1513,7 @@ gftp_get_transfer_status (gftp_transfer * tdata, ssize_t num_read)
   tempfle = tdata->curfle->data;
 
   if (g_thread_supported ())
-    g_static_mutex_unlock (&tdata->structmutex);
+    g_mutex_unlock (&tdata->structmutex);
 
   gftp_disconnect (tdata->fromreq);
   gftp_disconnect (tdata->toreq);
@@ -1562,7 +1562,7 @@ gftp_get_transfer_status (gftp_transfer * tdata, ssize_t num_read)
           (ret2 = gftp_connect (tdata->toreq)) == 0)
         {
           if (g_thread_supported ())
-            g_static_mutex_lock (&tdata->structmutex);
+            g_mutex_lock (&tdata->structmutex);
 
           tdata->resumed_bytes = tdata->resumed_bytes + tdata->trans_bytes - tdata->curresumed - tdata->curtrans;
           tdata->trans_bytes = 0;
@@ -1593,7 +1593,7 @@ gftp_get_transfer_status (gftp_transfer * tdata, ssize_t num_read)
           gettimeofday (&tdata->starttime, NULL);
 
           if (g_thread_supported ())
-            g_static_mutex_unlock (&tdata->structmutex);
+            g_mutex_unlock (&tdata->structmutex);
 
           return (GFTP_ERETRYABLE);
         }

--- a/lib/sockutils.c
+++ b/lib/sockutils.c
@@ -362,11 +362,11 @@ struct servent *
 r_getservbyname (const char *name, const char *proto,
                  struct servent *result_buf, int *h_errnop)
 {
-  static GStaticMutex servfunclock = G_STATIC_MUTEX_INIT;
+  static GMutex servfunclock;
   struct servent *sent;
 
   if (g_thread_supported ())
-    g_static_mutex_lock (&servfunclock);
+    g_mutex_lock (&servfunclock);
 
   if ((sent = getservbyname (name, proto)) == NULL)
     {
@@ -380,7 +380,7 @@ r_getservbyname (const char *name, const char *proto,
     }
 
   if (g_thread_supported ())
-    g_static_mutex_unlock (&servfunclock);
+    g_mutex_unlock (&servfunclock);
   return (sent);
 }
 

--- a/lib/sslcommon.c
+++ b/lib/sslcommon.c
@@ -233,7 +233,7 @@ _gftp_ssl_create_dyn_mutex (const char *file, int line)
   struct CRYPTO_dynlock_value *value;
 
   value = g_malloc0 (sizeof (*value));
-  value->mutex = g_mutex_new ();
+  g_mutex_init (value->mutex);
   return (value);
 }
 
@@ -253,7 +253,7 @@ static void
 _gftp_ssl_destroy_dyn_mutex (struct CRYPTO_dynlock_value *l,
                              const char *file, int line)
 {
-  g_mutex_free (l->mutex);
+  g_mutex_clear(l->mutex);
   g_free (l);
 }
 
@@ -271,7 +271,7 @@ _gftp_ssl_thread_setup (void)
   gftp_ssl_mutexes = g_malloc0 (CRYPTO_num_locks( ) * sizeof (*gftp_ssl_mutexes));
 
   for (i = 0; i < CRYPTO_num_locks ( ); i++)
-    gftp_ssl_mutexes[i] = g_mutex_new ();
+    g_mutex_init (gftp_ssl_mutexes[i]);
 
   CRYPTO_set_id_callback (_gftp_ssl_id_function);
   CRYPTO_set_locking_callback (_gftp_ssl_locking_function);

--- a/src/gtk/gtkui_transfer.c
+++ b/src/gtk/gtkui_transfer.c
@@ -112,7 +112,7 @@ gftpui_gtk_set_action (gftp_transfer * tdata, char * transfer_str,
   gftp_file * tempfle;
   int curpos;
 
-  g_static_mutex_lock (&tdata->structmutex);
+  g_mutex_lock (&tdata->structmutex);
 
   curpos = 0;
   filelist = tdata->files;
@@ -125,7 +125,7 @@ gftpui_gtk_set_action (gftp_transfer * tdata, char * transfer_str,
       gtk_clist_set_text (GTK_CLIST (tdata->clist), curpos, 3, transfer_str);
     }
 
-  g_static_mutex_unlock (&tdata->structmutex);
+  g_mutex_unlock (&tdata->structmutex);
 }
 
 
@@ -158,7 +158,7 @@ gftpui_gtk_ok (GtkWidget * widget, gpointer data)
   GList * templist;
 
   tdata = data;
-  g_static_mutex_lock (&tdata->structmutex);
+  g_mutex_lock (&tdata->structmutex);
   for (templist = tdata->files; templist != NULL; templist = templist->next)
     {
       tempfle = templist->data;
@@ -175,7 +175,7 @@ gftpui_gtk_ok (GtkWidget * widget, gpointer data)
   else
     tdata->show = 1;
 
-  g_static_mutex_unlock (&tdata->structmutex);
+  g_mutex_unlock (&tdata->structmutex);
 }
 
 
@@ -185,10 +185,10 @@ gftpui_gtk_cancel (GtkWidget * widget, gpointer data)
   gftp_transfer * tdata;
 
   tdata = data;
-  g_static_mutex_lock (&tdata->structmutex);
+  g_mutex_lock (&tdata->structmutex);
   tdata->show = 0;
   tdata->done = tdata->ready = 1;
-  g_static_mutex_unlock (&tdata->structmutex);
+  g_mutex_unlock (&tdata->structmutex);
 }
 
 

--- a/src/gtk/transfer.c
+++ b/src/gtk/transfer.c
@@ -637,9 +637,9 @@ transfer_done (GList * node)
       gtk_ctree_remove_node (GTK_CTREE (dlwdw), tdata->user_data);
     }
 
-  g_static_mutex_lock (&gftpui_common_transfer_mutex);
+  g_mutex_lock (&gftpui_common_transfer_mutex);
   gftp_file_transfers = g_list_remove_link (gftp_file_transfers, node);
-  g_static_mutex_unlock (&gftpui_common_transfer_mutex);
+  g_mutex_unlock (&gftpui_common_transfer_mutex);
 
   gdk_window_set_title (gtk_widget_get_parent_window (GTK_WIDGET(dlwdw)),
                         gftp_version);
@@ -768,7 +768,7 @@ update_file_status (gftp_transfer * tdata)
   intptr_t show_trans_in_title;
   gftp_file * tempfle;
   
-  g_static_mutex_lock (&tdata->statmutex);
+  g_mutex_lock (&tdata->statmutex);
   tempfle = tdata->curfle->data;
 
   remaining_secs = (tdata->total_bytes - tdata->trans_bytes - tdata->resumed_bytes) / 1024;
@@ -785,7 +785,7 @@ update_file_status (gftp_transfer * tdata)
 
   if (hours < 0 || mins < 0 || secs < 0)
     {
-      g_static_mutex_unlock (&tdata->statmutex);
+      g_mutex_unlock (&tdata->statmutex);
       return;
     }
 
@@ -808,7 +808,7 @@ update_file_status (gftp_transfer * tdata)
   if (!tdata->stalled)
     _setup_dlstr (tdata, tempfle, dlstr, sizeof (dlstr));
 
-  g_static_mutex_unlock (&tdata->statmutex);
+  g_mutex_unlock (&tdata->statmutex);
 
   gtk_ctree_node_set_text (GTK_CTREE (dlwdw), tdata->user_data, 1, totstr);
   
@@ -870,7 +870,7 @@ update_downloads (gpointer data)
       tdata = templist->data;
       if (tdata->ready)
         {
-          g_static_mutex_lock (&tdata->structmutex);
+          g_mutex_lock (&tdata->structmutex);
 
 	  if (tdata->next_file)
 	    on_next_transfer (tdata);
@@ -879,7 +879,7 @@ update_downloads (gpointer data)
 	  else if (tdata->done)
 	    {
 	      next = templist->next;
-              g_static_mutex_unlock (&tdata->structmutex);
+              g_mutex_unlock (&tdata->structmutex);
 	      transfer_done (templist);
 	      templist = next;
 	      continue;
@@ -898,7 +898,7 @@ update_downloads (gpointer data)
 	      if (tdata->started)
                 update_file_status (tdata);
 	    }
-          g_static_mutex_unlock (&tdata->structmutex);
+          g_mutex_unlock (&tdata->structmutex);
         }
       templist = templist->next;
     }
@@ -923,10 +923,10 @@ start_transfer (gpointer data)
   node = GTK_CLIST (dlwdw)->selection->data;
   transdata = gtk_ctree_node_get_row_data (GTK_CTREE (dlwdw), node);
 
-  g_static_mutex_lock (&transdata->transfer->structmutex);
+  g_mutex_lock (&transdata->transfer->structmutex);
   if (!transdata->transfer->started)
     create_transfer (transdata->transfer);
-  g_static_mutex_unlock (&transdata->transfer->structmutex);
+  g_mutex_unlock (&transdata->transfer->structmutex);
 }
 
 
@@ -1017,7 +1017,7 @@ move_transfer_up (gpointer data)
   if (transdata->curfle == NULL)
     return;
 
-  g_static_mutex_lock (&transdata->transfer->structmutex);
+  g_mutex_lock (&transdata->transfer->structmutex);
   if (transdata->curfle->prev != NULL && (!transdata->transfer->started ||
       (transdata->transfer->curfle != transdata->curfle && 
        transdata->transfer->curfle != transdata->curfle->prev)))
@@ -1054,7 +1054,7 @@ move_transfer_up (gpointer data)
                       transdata->curfle->next != NULL ?
                           ((gftp_file *) transdata->curfle->next->data)->user_data: NULL);
     }
-  g_static_mutex_unlock (&transdata->transfer->structmutex);
+  g_mutex_unlock (&transdata->transfer->structmutex);
 }
 
 
@@ -1077,7 +1077,7 @@ move_transfer_down (gpointer data)
   if (transdata->curfle == NULL)
     return;
 
-  g_static_mutex_lock (&transdata->transfer->structmutex);
+  g_mutex_lock (&transdata->transfer->structmutex);
   if (transdata->curfle->next != NULL && (!transdata->transfer->started ||
       (transdata->transfer->curfle != transdata->curfle && 
        transdata->transfer->curfle != transdata->curfle->next)))
@@ -1114,6 +1114,6 @@ move_transfer_down (gpointer data)
                       transdata->curfle->next != NULL ?
                           ((gftp_file *) transdata->curfle->next->data)->user_data: NULL);
     }
-  g_static_mutex_unlock (&transdata->transfer->structmutex);
+  g_mutex_unlock (&transdata->transfer->structmutex);
 }
 

--- a/src/uicommon/gftpui.c
+++ b/src/uicommon/gftpui.c
@@ -19,7 +19,7 @@
 
 #include "gftpui.h"
 
-GStaticMutex gftpui_common_transfer_mutex = G_STATIC_MUTEX_INIT;
+GMutex gftpui_common_transfer_mutex;
 volatile sig_atomic_t gftpui_common_child_process_done = 0;
 volatile sig_atomic_t gftpui_common_num_child_threads = 0;
 static gftp_logging_func gftpui_common_logfunc;
@@ -1132,7 +1132,7 @@ gftpui_common_add_file_transfer (gftp_request * fromreq, gftp_request * toreq,
   if (append_transfers && one_transfer && !show_dialog)
     {
       if (g_thread_supported ())
-        g_static_mutex_lock (&gftpui_common_transfer_mutex);
+        g_mutex_lock (&gftpui_common_transfer_mutex);
 
       for (templist = gftp_file_transfers;
            templist != NULL;
@@ -1141,14 +1141,14 @@ gftpui_common_add_file_transfer (gftp_request * fromreq, gftp_request * toreq,
           tdata = templist->data;
 
           if (g_thread_supported ())
-            g_static_mutex_lock (&tdata->structmutex);
+            g_mutex_lock (&tdata->structmutex);
 
           if (!compare_request (tdata->fromreq, fromreq, 0) ||
               !compare_request (tdata->toreq, toreq, 0) ||
               tdata->curfle == NULL)
             {
               if (g_thread_supported ())
-                g_static_mutex_unlock (&tdata->structmutex);
+                g_mutex_unlock (&tdata->structmutex);
 
               continue;
             }
@@ -1171,13 +1171,13 @@ gftpui_common_add_file_transfer (gftp_request * fromreq, gftp_request * toreq,
             }
 
           if (g_thread_supported ())
-            g_static_mutex_unlock (&tdata->structmutex);
+            g_mutex_unlock (&tdata->structmutex);
 
           break;
         }
 
       if (g_thread_supported ())
-        g_static_mutex_unlock (&gftpui_common_transfer_mutex);
+        g_mutex_unlock (&gftpui_common_transfer_mutex);
     }
   else
     templist = NULL;
@@ -1208,12 +1208,12 @@ gftpui_common_add_file_transfer (gftp_request * fromreq, gftp_request * toreq,
         }
 
       if (g_thread_supported ())
-        g_static_mutex_lock (&gftpui_common_transfer_mutex);
+        g_mutex_lock (&gftpui_common_transfer_mutex);
 
       gftp_file_transfers = g_list_append (gftp_file_transfers, tdata);
 
       if (g_thread_supported ())
-        g_static_mutex_unlock (&gftpui_common_transfer_mutex);
+        g_mutex_unlock (&gftpui_common_transfer_mutex);
 
       if (show_dialog)
         gftpui_ask_transfer (tdata);
@@ -1313,7 +1313,7 @@ _gftpui_common_do_transfer_file (gftp_transfer * tdata, gftp_file * curfle)
 void
 gftpui_common_skip_file_transfer (gftp_transfer * tdata, gftp_file * curfle)
 {
-  g_static_mutex_lock (&tdata->structmutex);
+  g_mutex_lock (&tdata->structmutex);
 
   if (tdata->started && !(curfle->transfer_action & GFTP_TRANS_ACTION_SKIP))
     {
@@ -1327,7 +1327,7 @@ gftpui_common_skip_file_transfer (gftp_transfer * tdata, gftp_file * curfle)
         tdata->total_bytes -= curfle->size;
     }
 
-  g_static_mutex_unlock (&tdata->structmutex);
+  g_mutex_unlock (&tdata->structmutex);
 
   if (curfle != NULL)
     tdata->fromreq->logging_function (gftp_logging_misc, tdata->fromreq,
@@ -1339,7 +1339,7 @@ gftpui_common_skip_file_transfer (gftp_transfer * tdata, gftp_file * curfle)
 void
 gftpui_common_cancel_file_transfer (gftp_transfer * tdata)
 {
-  g_static_mutex_lock (&tdata->structmutex);
+  g_mutex_lock (&tdata->structmutex);
 
   if (tdata->started)
     {
@@ -1352,7 +1352,7 @@ gftpui_common_cancel_file_transfer (gftp_transfer * tdata)
   tdata->fromreq->stopable = 0;
   tdata->toreq->stopable = 0;
 
-  g_static_mutex_unlock (&tdata->structmutex);
+  g_mutex_unlock (&tdata->structmutex);
 
   tdata->fromreq->logging_function (gftp_logging_misc, tdata->fromreq,
                                     _("Stopping the transfer on host %s\n"),
@@ -1366,7 +1366,7 @@ _gftpui_common_next_file_in_trans (gftp_transfer * tdata)
   gftp_file * curfle;
 
   if (g_thread_supported ())
-    g_static_mutex_lock (&tdata->structmutex);
+    g_mutex_lock (&tdata->structmutex);
 
   tdata->curtrans = 0;
   tdata->next_file = 1;
@@ -1376,7 +1376,7 @@ _gftpui_common_next_file_in_trans (gftp_transfer * tdata)
   tdata->curfle = tdata->curfle->next;
 
   if (g_thread_supported ())
-    g_static_mutex_unlock (&tdata->structmutex);
+    g_mutex_unlock (&tdata->structmutex);
 }
 
 
@@ -1424,13 +1424,13 @@ _gftpui_common_trans_file_or_dir (gftp_transfer * tdata)
   int ret;
 
   if (g_thread_supported ())
-    g_static_mutex_lock (&tdata->structmutex);
+    g_mutex_lock (&tdata->structmutex);
 
   curfle = tdata->curfle->data;
   tdata->current_file_number++;
 
   if (g_thread_supported ())
-    g_static_mutex_unlock (&tdata->structmutex);
+    g_mutex_unlock (&tdata->structmutex);
 
   if (curfle->transfer_action == GFTP_TRANS_ACTION_SKIP)
     {
@@ -1482,14 +1482,14 @@ _gftpui_common_trans_file_or_dir (gftp_transfer * tdata)
       else
         {
           if (g_thread_supported ())
-            g_static_mutex_lock (&tdata->structmutex);
+            g_mutex_lock (&tdata->structmutex);
 
           tdata->curtrans = 0;
           tdata->curresumed = curfle->transfer_action == GFTP_TRANS_ACTION_RESUME ? curfle->startsize : 0;
           tdata->resumed_bytes += tdata->curresumed;
 
           if (g_thread_supported ())
-            g_static_mutex_unlock (&tdata->structmutex);
+            g_mutex_unlock (&tdata->structmutex);
 
           ret = _gftpui_common_do_transfer_file (tdata, curfle);
         }

--- a/src/uicommon/gftpui.h
+++ b/src/uicommon/gftpui.h
@@ -88,7 +88,7 @@ typedef struct _gftpui_common_curtrans_data
 extern sigjmp_buf gftpui_common_jmp_environment;
 extern volatile int gftpui_common_use_jmp_environment;
 extern gftpui_common_methods gftpui_common_commands[];
-extern GStaticMutex gftpui_common_transfer_mutex;
+extern GMutex gftpui_common_transfer_mutex;
 extern volatile sig_atomic_t gftpui_common_child_process_done;
 
 /* gftpui.c */


### PR DESCRIPTION
With this change gftp will now officially require at least GLib 2.32 since we are no longer calling the deprecated functions

(a future changeset will remove all of the now legacy broken glib 1.x code)