### PR TITLE
Gtk1x removal

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -201,7 +201,7 @@ GTHREAD_LIBS=""
 if test "x$enable_gtkport" = "xyes" ; then
 
   if test "x$GFTP_GTK" = "x" ; then
-    PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.0.0], found_glib20=1, found_glib20=0)
+    PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.31.0], found_glib20=1, found_glib20=0)
 
     PKG_CHECK_MODULES(GTHREADS, gthread-2.0 >=  2.2.0, HAVE_GTHREADS="yes")
     AC_SUBST(GTHREADS_CFLAGS)
@@ -225,7 +225,7 @@ if test "x$enable_gtkport" = "xyes" ; then
       PKG_CHECK_MODULES([GTK], [gtk+-3.0 >= 3.0.0], GFTP_GTK=gftp-gtk, AC_MSG_ERROR(You have GLIB 2.0 installed but I cannot find GTK+ 3.0. Run configure without --enable-gtk30 or install GTK+ 3.0))
     fi
   else
-    PKG_CHECK_MODULES([GLIB], [glib-1.0 >= 1.0.0])
+    PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.31.0])
     if test "x$HAVE_GTHREADS" != xyes ; then
       AC_CHECK_LIB(gthread, g_thread_init, GTHREAD_LIBS="-lgthread")
     fi

--- a/src/gtk/bookmarks.c
+++ b/src/gtk/bookmarks.c
@@ -384,7 +384,6 @@ bm_close_dialog (GtkWidget * widget, GtkWidget * dialog)
 }
 
 
-#if GTK_MAJOR_VERSION > 1 
 static void
 editbm_action (GtkWidget * widget, gint response, gpointer user_data)
 {
@@ -397,7 +396,6 @@ editbm_action (GtkWidget * widget, gint response, gpointer user_data)
         bm_close_dialog (NULL, widget);
     }
 }
-#endif
 
 
 static void
@@ -421,16 +419,9 @@ do_make_new (gpointer data, gftp_dialog_data * ddata)
     }
 
   newentry = g_malloc0 (sizeof (*newentry));
-#if GTK_MAJOR_VERSION == 1
-  newentry->path = g_strdup (str);
-
-  while ((pos = strchr (str, '/')) != NULL)
-    *pos++ = ' ';
-#else
   newentry->path = g_strdup (str);
   while ((pos = g_utf8_strchr (newentry->path, -1, '/')) != NULL)
     *pos++ = ' ';
-#endif
 
   newentry->prev = new_bookmarks;
   if (data)
@@ -792,18 +783,6 @@ entry_apply_changes (GtkWidget * widget, gftp_bookmarks_var * entry)
 }
 
 
-#if GTK_MAJOR_VERSION == 1
-
-static void
-entry_close_dialog (void * data)
-{
-  gtk_widget_destroy (bm_dialog);
-  bm_dialog = NULL;
-}
-
-
-#else
-
 static void
 bmedit_action (GtkWidget * widget, gint response, gpointer user_data)
 {
@@ -817,7 +796,6 @@ bmedit_action (GtkWidget * widget, gint response, gpointer user_data)
         bm_dialog = NULL;
     }
 }   
-#endif
 
 
 static void
@@ -843,18 +821,13 @@ edit_entry (gpointer data)
   if (entry == NULL || entry == new_bookmarks)
     return;
 
-#if GTK_MAJOR_VERSION == 1
-  bm_dialog = gtk_dialog_new ();
-  gtk_window_set_title (GTK_WINDOW (bm_dialog), _("Edit Entry"));
-  gtk_box_set_spacing (GTK_BOX (GTK_DIALOG (bm_dialog)->action_area), 15);
-#else
   bm_dialog = gtk_dialog_new_with_buttons (_("Edit Entry"), NULL, 0,
                                            GTK_STOCK_CANCEL,
                                            GTK_RESPONSE_CANCEL,
                                            GTK_STOCK_SAVE,
                                            GTK_RESPONSE_OK,
                                            NULL);
-#endif
+
   gtk_window_set_wmclass (GTK_WINDOW (bm_dialog), "Edit Bookmark Entry",
                           "gFTP");
   gtk_window_set_position (GTK_WINDOW (bm_dialog), GTK_WIN_POS_MOUSE);
@@ -1037,30 +1010,8 @@ edit_entry (gpointer data)
     }
   gtk_widget_show (anon_chk);
 
-#if GTK_MAJOR_VERSION == 1
-  tempwid = gtk_button_new_with_label (_("OK"));
-  gtk_box_pack_start (GTK_BOX (GTK_DIALOG (bm_dialog)->action_area), tempwid,
-		      TRUE, TRUE, 0);
-  gtk_signal_connect (GTK_OBJECT (tempwid), "clicked",
-		      GTK_SIGNAL_FUNC (entry_apply_changes),
-		      (gpointer) entry);
-  gtk_signal_connect_object (GTK_OBJECT (tempwid), "clicked",
-			     GTK_SIGNAL_FUNC (entry_close_dialog), NULL);
-  GTK_WIDGET_SET_FLAGS (tempwid, GTK_CAN_DEFAULT);
-  gtk_widget_show (tempwid);
-
-  tempwid = gtk_button_new_with_label (_("  Cancel  "));
-  gtk_box_pack_start (GTK_BOX (GTK_DIALOG (bm_dialog)->action_area), tempwid,
-		      TRUE, TRUE, 0);
-  gtk_signal_connect_object (GTK_OBJECT (tempwid), "clicked",
-			     GTK_SIGNAL_FUNC (entry_close_dialog), NULL);
-  GTK_WIDGET_SET_FLAGS (tempwid, GTK_CAN_DEFAULT);
-  gtk_widget_grab_focus (tempwid);
-  gtk_widget_show (tempwid);
-#else
   g_signal_connect (GTK_OBJECT (bm_dialog), "response",
                     G_CALLBACK (bmedit_action), (gpointer) entry);
-#endif
 
   gftp_gtk_setup_bookmark_options (notebook, entry);
 
@@ -1209,9 +1160,6 @@ edit_bookmarks (gpointer data)
     {N_("/File/sep"), NULL, 0, 0, MN_("<Separator>")},
     {N_("/File/_Close"), NULL, gtk_widget_destroy, 0, MS_(GTK_STOCK_CLOSE)}
   };
-#if GTK_MAJOR_VERSION == 1
-  GtkWidget * tempwid;
-#endif
 
   if (edit_bookmarks_dialog != NULL)
     {
@@ -1222,12 +1170,6 @@ edit_bookmarks (gpointer data)
   new_bookmarks = copy_bookmarks (gftp_bookmarks);
   new_bookmarks_htable = build_bookmarks_hash_table (new_bookmarks);
 
-#if GTK_MAJOR_VERSION == 1
-  edit_bookmarks_dialog = gtk_dialog_new ();
-  gtk_window_set_title (GTK_WINDOW (edit_bookmarks_dialog),
-                        _("Edit Bookmarks"));
-  gtk_box_set_spacing (GTK_BOX (GTK_DIALOG (edit_bookmarks_dialog)->action_area), 15);
-#else
   edit_bookmarks_dialog = gtk_dialog_new_with_buttons (_("Edit Bookmarks"),
                                                        NULL, 0, 
                                                        GTK_STOCK_CANCEL,
@@ -1235,7 +1177,7 @@ edit_bookmarks (gpointer data)
 						       GTK_STOCK_SAVE,
                                                        GTK_RESPONSE_OK,
                                                        NULL);
-#endif
+
   gtk_window_set_wmclass (GTK_WINDOW(edit_bookmarks_dialog), "Edit Bookmarks",
                           "gFTP");
   gtk_window_set_position (GTK_WINDOW (edit_bookmarks_dialog),
@@ -1287,31 +1229,8 @@ edit_bookmarks (gpointer data)
   gtk_ctree_set_drag_compare_func (GTK_CTREE(tree), &move_possible);
   gtk_widget_show (tree);
 
-#if GTK_MAJOR_VERSION == 1
-  tempwid = gtk_button_new_with_label (_("OK"));
-  gtk_box_pack_start (GTK_BOX (GTK_DIALOG (edit_bookmarks_dialog)->action_area),
-                      tempwid, TRUE, TRUE, 0);
-  gtk_signal_connect (GTK_OBJECT (tempwid), "clicked",
-		      GTK_SIGNAL_FUNC (bm_apply_changes), NULL);
-  gtk_signal_connect (GTK_OBJECT (tempwid), "clicked",
-		      GTK_SIGNAL_FUNC (bm_close_dialog),
-                      (gpointer) edit_bookmarks_dialog);
-  GTK_WIDGET_SET_FLAGS (tempwid, GTK_CAN_DEFAULT);
-  gtk_widget_show (tempwid);
-
-  tempwid = gtk_button_new_with_label (_("  Cancel  "));
-  gtk_box_pack_start (GTK_BOX (GTK_DIALOG (edit_bookmarks_dialog)->action_area),
-                      tempwid, TRUE, TRUE, 0);
-  gtk_signal_connect (GTK_OBJECT (tempwid), "clicked",
-		      GTK_SIGNAL_FUNC (bm_close_dialog),
-                      (gpointer) edit_bookmarks_dialog);
-  GTK_WIDGET_SET_FLAGS (tempwid, GTK_CAN_DEFAULT);
-  gtk_widget_grab_focus (tempwid);
-  gtk_widget_show (tempwid);
-#else
   g_signal_connect (GTK_OBJECT (edit_bookmarks_dialog), "response",
                     G_CALLBACK (editbm_action), NULL);
-#endif
 
   gtk_widget_show (edit_bookmarks_dialog);
 

--- a/src/gtk/chmod_dialog.c
+++ b/src/gtk/chmod_dialog.c
@@ -102,7 +102,6 @@ dochmod (GtkWidget * widget, gftp_window_data * wdata)
 }
 
 
-#if GTK_MAJOR_VERSION > 1
 static void
 chmod_action (GtkWidget * widget, gint response, gpointer wdata)
 {
@@ -115,7 +114,6 @@ chmod_action (GtkWidget * widget, gint response, gpointer wdata)
         gtk_widget_destroy (widget);
     }
 }
-#endif
 
 
 void
@@ -131,20 +129,13 @@ chmod_dialog (gpointer data)
   if (!check_status (_("Chmod"), wdata, gftpui_common_use_threads (wdata->request), 0, 1, wdata->request->chmod != NULL))
     return;
 
-#if GTK_MAJOR_VERSION == 1
-  dialog = gtk_dialog_new ();
-  gtk_window_set_title (GTK_WINDOW (dialog), _("Chmod"));
-  gtk_container_border_width (GTK_CONTAINER (GTK_DIALOG (dialog)->action_area),
-                              5);
-  gtk_box_set_homogeneous (GTK_BOX (GTK_DIALOG (dialog)->action_area), TRUE);
-#else
   dialog = gtk_dialog_new_with_buttons (_("Chmod"), NULL, 0,
                                         GTK_STOCK_CANCEL,
                                         GTK_RESPONSE_CANCEL,
                                         GTK_STOCK_OK,
                                         GTK_RESPONSE_OK,
                                         NULL);
-#endif
+
   gtk_window_set_wmclass (GTK_WINDOW(dialog), "Chmod", "gFTP");
   gtk_window_set_position (GTK_WINDOW (dialog), GTK_WIN_POS_MOUSE);
   gtk_box_set_spacing (GTK_BOX (GTK_DIALOG (dialog)->vbox), 5);
@@ -248,31 +239,8 @@ chmod_dialog (gpointer data)
   gtk_box_pack_start (GTK_BOX (vbox), ox, FALSE, FALSE, 0);
   gtk_widget_show (ox);
 
-#if GTK_MAJOR_VERSION == 1
-  tempwid = gtk_button_new_with_label (_("OK"));
-  GTK_WIDGET_SET_FLAGS (tempwid, GTK_CAN_DEFAULT);
-  gtk_box_pack_start (GTK_BOX (GTK_DIALOG (dialog)->action_area), tempwid,
-		      TRUE, TRUE, 0);
-  gtk_signal_connect (GTK_OBJECT (tempwid), "clicked",
-		      GTK_SIGNAL_FUNC (dochmod), (gpointer) wdata);
-  gtk_signal_connect_object (GTK_OBJECT (tempwid), "clicked",
-			     GTK_SIGNAL_FUNC (gtk_widget_destroy),
-			     GTK_OBJECT (dialog));
-  gtk_widget_grab_default (tempwid);
-  gtk_widget_show (tempwid);
-
-  tempwid = gtk_button_new_with_label (_("  Cancel  "));
-  GTK_WIDGET_SET_FLAGS (tempwid, GTK_CAN_DEFAULT);
-  gtk_box_pack_start (GTK_BOX (GTK_DIALOG (dialog)->action_area), tempwid,
-		      TRUE, TRUE, 0);
-  gtk_signal_connect_object (GTK_OBJECT (tempwid), "clicked",
-			     GTK_SIGNAL_FUNC (gtk_widget_destroy),
-			     GTK_OBJECT (dialog));
-  gtk_widget_show (tempwid);
-#else
   g_signal_connect (GTK_OBJECT (dialog), "response",
                     G_CALLBACK (chmod_action), wdata);
-#endif
 
   if (IS_ONE_SELECTED (wdata))
     {

--- a/src/gtk/gftp-gtk.c
+++ b/src/gtk/gftp-gtk.c
@@ -29,9 +29,7 @@ GtkWidget * stop_btn, * hostedit, * useredit, * passedit, * portedit, * logwdw,
           * upload_right_arrow, * openurl_btn;
 GtkTooltips * openurl_tooltip;
 GtkAdjustment * logwdw_vadj;
-#if GTK_MAJOR_VERSION > 1
 GtkTextMark * logwdw_textmark;
-#endif
 int local_start, remote_start, trans_start;
 GHashTable * graphic_hash_table = NULL;
 GtkItemFactoryEntry * menus = NULL;
@@ -483,11 +481,7 @@ CreateConnectToolbar (GtkWidget * parent)
   gtk_container_border_width (GTK_CONTAINER (openurl_btn), 1);
   gtk_box_pack_start (GTK_BOX (box), openurl_btn, FALSE, FALSE, 0);
 
-#if GTK_MAJOR_VERSION == 1
-  tempwid = gtk_label_new (_("Host: "));
-#else
   tempwid = gtk_label_new_with_mnemonic (_("_Host: "));
-#endif
 
   gtk_box_pack_start (GTK_BOX (box), tempwid, FALSE, FALSE, 0);
 
@@ -506,10 +500,9 @@ CreateConnectToolbar (GtkWidget * parent)
 
   gftp_lookup_global_option ("host_value", &tempstr);
   gtk_entry_set_text (GTK_ENTRY (GTK_COMBO (hostedit)->entry), tempstr);
-#if GTK_MAJOR_VERSION > 1
   gtk_label_set_mnemonic_widget (GTK_LABEL (tempwid),
                                  GTK_COMBO (hostedit)->entry);
-#endif
+
   gtk_box_pack_start (GTK_BOX (box), hostedit, TRUE, TRUE, 0);
 
   tempwid = gtk_label_new (_("Port: "));
@@ -532,11 +525,7 @@ CreateConnectToolbar (GtkWidget * parent)
   gtk_entry_set_text (GTK_ENTRY (GTK_COMBO (portedit)->entry), tempstr);
   gtk_box_pack_start (GTK_BOX (box), portedit, FALSE, FALSE, 0);
 
-#if GTK_MAJOR_VERSION == 1
-  tempwid = gtk_label_new (_("User: "));
-#else
   tempwid = gtk_label_new_with_mnemonic (_("_User: "));
-#endif
   gtk_box_pack_start (GTK_BOX (box), tempwid, FALSE, FALSE, 0);
 
   useredit = gtk_combo_new ();
@@ -554,10 +543,8 @@ CreateConnectToolbar (GtkWidget * parent)
 
   gftp_lookup_global_option ("user_value", &tempstr);
   gtk_entry_set_text (GTK_ENTRY (GTK_COMBO (useredit)->entry), tempstr);
-#if GTK_MAJOR_VERSION > 1
   gtk_label_set_mnemonic_widget (GTK_LABEL (tempwid),
                                  GTK_COMBO (useredit)->entry);
-#endif
   gtk_box_pack_start (GTK_BOX (box), useredit, TRUE, TRUE, 0);
 
   tempwid = gtk_label_new (_("Pass: "));
@@ -599,12 +586,8 @@ CreateConnectToolbar (GtkWidget * parent)
   gtk_option_menu_set_menu (GTK_OPTION_MENU (optionmenu), protocol_menu);
   gtk_option_menu_set_history (GTK_OPTION_MENU (optionmenu), num);
 
-#if GTK_MAJOR_VERSION == 1
-  tempwid = toolbar_pixmap (parent, "stop.xpm");
-#else
   tempwid = gtk_image_new_from_stock (GTK_STOCK_STOP,
                                       GTK_ICON_SIZE_LARGE_TOOLBAR);
-#endif
 
   stop_btn = gtk_button_new ();
 
@@ -909,12 +892,10 @@ CreateFTPWindows (GtkWidget * ui)
   gftp_config_list_vars * tmplistvar;
   char *dltitles[2];
   intptr_t tmplookup;
-#if GTK_MAJOR_VERSION > 1
   GtkTextBuffer * textbuf;
   GtkTextIter iter;
   GtkTextTag *tag;
   GdkColor * fore;
-#endif
 
   memset (&window1, 0, sizeof (window1));
   memset (&window2, 0, sizeof (window2));
@@ -950,12 +931,8 @@ CreateFTPWindows (GtkWidget * ui)
   gtk_container_border_width (GTK_CONTAINER (dlbox), 5);
   gtk_box_pack_start (GTK_BOX (box), dlbox, FALSE, FALSE, 0);
 
-#if GTK_MAJOR_VERSION == 1
-  tempwid = toolbar_pixmap (ui, "right.xpm");
-#else
   tempwid = gtk_image_new_from_stock (GTK_STOCK_GO_FORWARD,
                                       GTK_ICON_SIZE_SMALL_TOOLBAR);
-#endif
 
   upload_right_arrow = gtk_button_new ();
   gtk_box_pack_start (GTK_BOX (dlbox), upload_right_arrow, TRUE, FALSE, 0);
@@ -963,12 +940,8 @@ CreateFTPWindows (GtkWidget * ui)
 			     GTK_SIGNAL_FUNC (put_files), NULL);
   gtk_container_add (GTK_CONTAINER (upload_right_arrow), tempwid);
 
-#if GTK_MAJOR_VERSION == 1
-  tempwid = toolbar_pixmap (ui, "left.xpm");
-#else
   tempwid = gtk_image_new_from_stock (GTK_STOCK_GO_BACK,
                                       GTK_ICON_SIZE_SMALL_TOOLBAR);
-#endif
 
   download_left_arrow = gtk_button_new ();
   gtk_box_pack_start (GTK_BOX (dlbox), download_left_arrow, TRUE, FALSE, 0);
@@ -1016,24 +989,6 @@ CreateFTPWindows (GtkWidget * ui)
   gftp_lookup_global_option ("log_height", &tmplookup);
   gtk_widget_set_size_request (log_table, -1, tmplookup);
 
-#if GTK_MAJOR_VERSION == 1
-  logwdw = gtk_text_new (NULL, NULL);
-
-  gtk_text_set_editable (GTK_TEXT (logwdw), FALSE);
-  gtk_text_set_word_wrap (GTK_TEXT (logwdw), TRUE);
-
-  gtk_table_attach (GTK_TABLE (log_table), logwdw, 0, 1, 0, 1,
-		    GTK_FILL | GTK_EXPAND, GTK_FILL | GTK_EXPAND | GTK_SHRINK,
-		    0, 0);
-  gtk_signal_connect (GTK_OBJECT (logwdw), "button_press_event",
-		      GTK_SIGNAL_FUNC (menu_mouse_click), 
-                      (gpointer) log_factory);
-
-  tempwid = gtk_vscrollbar_new (GTK_TEXT (logwdw)->vadj);
-  gtk_table_attach (GTK_TABLE (log_table), tempwid, 1, 2, 0, 1,
-		    GTK_FILL, GTK_EXPAND | GTK_FILL | GTK_SHRINK, 0, 0);
-  logwdw_vadj = GTK_TEXT (logwdw)->vadj;
-#else
   logwdw = gtk_text_view_new ();
   gtk_text_view_set_editable (GTK_TEXT_VIEW (logwdw), FALSE);
   gtk_text_view_set_cursor_visible (GTK_TEXT_VIEW (logwdw), FALSE);
@@ -1068,7 +1023,7 @@ CreateFTPWindows (GtkWidget * ui)
   logwdw_vadj = gtk_scrolled_window_get_vadjustment (GTK_SCROLLED_WINDOW (tempwid));
   gtk_text_buffer_get_iter_at_offset (textbuf, &iter, 0);
   logwdw_textmark = gtk_text_buffer_create_mark (textbuf, "end", &iter, 1);
-#endif
+
   gtk_paned_pack2 (GTK_PANED (logpane), log_table, 1, 1);
   gtk_box_pack_start (GTK_BOX (mainvbox), logpane, TRUE, TRUE, 0);
 
@@ -1208,19 +1163,13 @@ sortrows (GtkCList * clist, gint column, gpointer data)
     {
       sort_wid = gtk_clist_get_column_widget (clist, 0);
       gtk_widget_destroy (sort_wid);
-#if GTK_MAJOR_VERSION == 1
-      if (sortasds)
-	sort_wid = toolbar_pixmap (wdata->listbox, "down.xpm");
-      else
-	sort_wid = toolbar_pixmap (wdata->listbox, "up.xpm");
-#else
+
       if (sortasds)
         sort_wid = gtk_image_new_from_stock (GTK_STOCK_SORT_ASCENDING, 
                                              GTK_ICON_SIZE_SMALL_TOOLBAR);
       else
         sort_wid = gtk_image_new_from_stock (GTK_STOCK_SORT_DESCENDING, 
                                              GTK_ICON_SIZE_SMALL_TOOLBAR);
-#endif
 
       gtk_clist_set_column_widget (clist, 0, sort_wid);
     }
@@ -1373,9 +1322,7 @@ main (int argc, char **argv)
   g_thread_init (NULL);
 #endif
 
-#if GTK_MAJOR_VERSION > 1
   gdk_threads_init();
-#endif
   GDK_THREADS_ENTER ();
   main_thread_id = pthread_self ();
   gtk_set_locale ();

--- a/src/gtk/gtkui.c
+++ b/src/gtk/gtkui.c
@@ -126,11 +126,7 @@ gftpui_prompt_username (void *uidata, gftp_request * request)
   while (request->stopable)
     {
       GDK_THREADS_LEAVE ();
-#if GTK_MAJOR_VERSION == 1
-      g_main_iteration (TRUE);
-#else
       g_main_context_iteration (NULL, TRUE);
-#endif
     }
 }
 
@@ -148,11 +144,7 @@ gftpui_prompt_password (void *uidata, gftp_request * request)
   while (request->stopable)
     {
       GDK_THREADS_LEAVE ();
-#if GTK_MAJOR_VERSION == 1
-      g_main_iteration (TRUE);
-#else
       g_main_context_iteration (NULL, TRUE);
-#endif
     }
 }
 
@@ -248,11 +240,7 @@ gftpui_generic_thread (void * (*func) (void *), void *data)
   while (wdata->request->stopable)
     {
       GDK_THREADS_LEAVE ();
-#if GTK_MAJOR_VERSION == 1
-      g_main_iteration (TRUE);
-#else
       g_main_context_iteration (NULL, TRUE);
-#endif
     }
 
   _gftpui_teardown_wakeup_main_thread (cdata->request, handler);
@@ -534,11 +522,7 @@ gftpui_protocol_ask_yes_no (gftp_request * request, char *title,
       while (answer == -1)
         {
           GDK_THREADS_LEAVE ();
-#if GTK_MAJOR_VERSION == 1
-          g_main_iteration (TRUE);
-#else
           g_main_context_iteration (NULL, TRUE);
-#endif
         }
     }
 
@@ -590,11 +574,7 @@ gftpui_protocol_ask_user_input (gftp_request * request, char *title,
       while (*buf == '\0' && *(buf + 1) == ' ')
         {
           GDK_THREADS_LEAVE ();
-#if GTK_MAJOR_VERSION == 1
-          g_main_iteration (TRUE);
-#else
           g_main_context_iteration (NULL, TRUE);
-#endif
         }
     }
 

--- a/src/gtk/gtkui_transfer.c
+++ b/src/gtk/gtkui_transfer.c
@@ -192,7 +192,6 @@ gftpui_gtk_cancel (GtkWidget * widget, gpointer data)
 }
 
 
-#if GTK_MAJOR_VERSION > 1
 static void
 gftpui_gtk_transfer_action (GtkWidget * widget, gint response,
                             gpointer user_data)
@@ -210,7 +209,6 @@ gftpui_gtk_transfer_action (GtkWidget * widget, gint response,
         gtk_widget_destroy (widget);
     }
 }   
-#endif
 
 
 void
@@ -229,25 +227,13 @@ gftpui_ask_transfer (gftp_transfer * tdata)
   dltitles[2] = tdata->toreq->hostname;
   dltitles[3] = _("Action");
 
-#if GTK_MAJOR_VERSION == 1
-  dialog = gtk_dialog_new ();
-  gtk_grab_add (dialog);
-  gtk_window_set_title (GTK_WINDOW (dialog), _("Transfer Files"));
-  gtk_container_border_width (GTK_CONTAINER (GTK_DIALOG (dialog)->action_area), 5);
-  gtk_box_set_spacing (GTK_BOX (GTK_DIALOG (dialog)->action_area), 35);
-  gtk_box_set_homogeneous (GTK_BOX (GTK_DIALOG (dialog)->action_area), TRUE);
-
-  gtk_signal_connect_object (GTK_OBJECT (dialog), "delete_event",
-                             GTK_SIGNAL_FUNC (gtk_widget_destroy),
-                             GTK_OBJECT (dialog));
-#else
   dialog = gtk_dialog_new_with_buttons (_("Transfer Files"), NULL, 0, 
                                         GTK_STOCK_CANCEL,
                                         GTK_RESPONSE_CANCEL,
                                         GTK_STOCK_OK,
                                         GTK_RESPONSE_OK,
                                         NULL);
-#endif
+
   gtk_window_set_wmclass (GTK_WINDOW(dialog), "transfer", "gFTP");
   gtk_window_set_position (GTK_WINDOW (dialog), GTK_WIN_POS_MOUSE);
   gtk_container_border_width (GTK_CONTAINER (GTK_DIALOG (dialog)->vbox), 10);
@@ -266,13 +252,8 @@ gftpui_ask_transfer (gftp_transfer * tdata)
   tdata->clist = gtk_clist_new_with_titles (4, dltitles);
   gtk_container_add (GTK_CONTAINER (scroll), tdata->clist);
 
-#if GTK_MAJOR_VERSION == 1
-  gtk_clist_set_selection_mode (GTK_CLIST (tdata->clist),
-				GTK_SELECTION_EXTENDED);
-#else
   gtk_clist_set_selection_mode (GTK_CLIST (tdata->clist),
 				GTK_SELECTION_MULTIPLE);
-#endif
   gtk_clist_set_column_width (GTK_CLIST (tdata->clist), 0, 100);
   gtk_clist_set_column_justification (GTK_CLIST (tdata->clist), 1,
 				      GTK_JUSTIFY_RIGHT);
@@ -371,33 +352,8 @@ gftpui_ask_transfer (gftp_transfer * tdata)
 		      GTK_SIGNAL_FUNC (gftpui_gtk_trans_unselectall), (gpointer) tdata);
   gtk_widget_show (tempwid);
 
-#if GTK_MAJOR_VERSION == 1
-  tempwid = gtk_button_new_with_label (_("OK"));
-  GTK_WIDGET_SET_FLAGS (tempwid, GTK_CAN_DEFAULT);
-  gtk_box_pack_start (GTK_BOX (GTK_DIALOG (dialog)->action_area), tempwid,
-		      TRUE, TRUE, 0);
-  gtk_signal_connect (GTK_OBJECT (tempwid), "clicked",
-                      GTK_SIGNAL_FUNC (gftpui_gtk_ok), (gpointer) tdata);
-  gtk_signal_connect_object (GTK_OBJECT (tempwid), "clicked",
-			     GTK_SIGNAL_FUNC (gtk_widget_destroy),
-			     GTK_OBJECT (dialog));
-  gtk_widget_grab_default (tempwid);
-  gtk_widget_show (tempwid);
-
-  tempwid = gtk_button_new_with_label (_("  Cancel  "));
-  GTK_WIDGET_SET_FLAGS (tempwid, GTK_CAN_DEFAULT);
-  gtk_box_pack_start (GTK_BOX (GTK_DIALOG (dialog)->action_area), tempwid,
-		      TRUE, TRUE, 0);
-  gtk_signal_connect (GTK_OBJECT (tempwid), "clicked",
-		      GTK_SIGNAL_FUNC (gftpui_gtk_cancel), (gpointer) tdata);
-  gtk_signal_connect_object (GTK_OBJECT (tempwid), "clicked",
-			     GTK_SIGNAL_FUNC (gtk_widget_destroy),
-			     GTK_OBJECT (dialog));
-  gtk_widget_show (tempwid);
-#else
   g_signal_connect (GTK_OBJECT (dialog), "response",
                     G_CALLBACK (gftpui_gtk_transfer_action),(gpointer) tdata);
-#endif
 
   gtk_widget_show (dialog);
   dialog = NULL;

--- a/src/gtk/menu-items.c
+++ b/src/gtk/menu-items.c
@@ -262,11 +262,6 @@ clearlog (gpointer data)
 {
   gint len;
 
-#if GTK_MAJOR_VERSION == 1
-  len = gtk_text_get_length (GTK_TEXT (logwdw));
-  gtk_text_set_point (GTK_TEXT (logwdw), len);
-  gtk_text_backward_delete (GTK_TEXT (logwdw), len);
-#else
   GtkTextBuffer * textbuf;
   GtkTextIter iter, iter2;
 
@@ -275,7 +270,6 @@ clearlog (gpointer data)
   gtk_text_buffer_get_iter_at_offset (textbuf, &iter, 0);
   gtk_text_buffer_get_iter_at_offset (textbuf, &iter2, len);
   gtk_text_buffer_delete (textbuf, &iter, &iter2);
-#endif
 }
 
 
@@ -286,10 +280,8 @@ viewlog (gpointer data)
   gint textlen;
   ssize_t len;
   int fd;
-#if GTK_MAJOR_VERSION > 1
   GtkTextBuffer * textbuf;
   GtkTextIter iter, iter2;
-#endif
 
   tempstr = g_strconcat (g_get_tmp_dir (), "/gftp-view.XXXXXXXXXX", NULL);
   if ((fd = mkstemp (tempstr)) < 0)
@@ -302,10 +294,6 @@ viewlog (gpointer data)
     }
   chmod (tempstr, S_IRUSR | S_IWUSR);
   
-#if GTK_MAJOR_VERSION == 1
-  textlen = gtk_text_get_length (GTK_TEXT (logwdw));
-  txt = gtk_editable_get_chars (GTK_EDITABLE (logwdw), 0, -1);
-#else
   textbuf = gtk_text_view_get_buffer (GTK_TEXT_VIEW (logwdw));
   textlen = gtk_text_buffer_get_char_count (textbuf);
   gtk_text_buffer_get_iter_at_offset (textbuf, &iter, 0);
@@ -315,7 +303,7 @@ viewlog (gpointer data)
   /* gtk_text_buffer_get_char_count() returns the number of characters,
      not bytes. So get the number of bytes that need to be written out */
   textlen = strlen (txt);
-#endif
+
   pos = txt;
 
   while (textlen > 0)
@@ -350,10 +338,8 @@ dosavelog (GtkWidget * widget, GtkFileSelection * fs)
   ssize_t len;
   FILE *fd;
   int ok;
-#if GTK_MAJOR_VERSION > 1
   GtkTextBuffer * textbuf;
   GtkTextIter iter, iter2;
-#endif
 
   filename = gtk_file_selection_get_filename (GTK_FILE_SELECTION (fs));
   if ((fd = fopen (filename, "w")) == NULL)
@@ -364,10 +350,6 @@ dosavelog (GtkWidget * widget, GtkFileSelection * fs)
       return;
     }
 
-#if GTK_MAJOR_VERSION == 1
-  textlen = gtk_text_get_length (GTK_TEXT (logwdw));
-  txt = gtk_editable_get_chars (GTK_EDITABLE (logwdw), 0, -1);
-#else
   textbuf = gtk_text_view_get_buffer (GTK_TEXT_VIEW (logwdw));
   textlen = gtk_text_buffer_get_char_count (textbuf);
   gtk_text_buffer_get_iter_at_offset (textbuf, &iter, 0);
@@ -377,7 +359,6 @@ dosavelog (GtkWidget * widget, GtkFileSelection * fs)
   /* gtk_text_buffer_get_char_count() returns the number of characters,
      not bytes. So get the number of bytes that need to be written out */
   textlen = strlen (txt);
-#endif
 
   ok = 1;
   pos = txt;
@@ -439,27 +420,18 @@ about_dialog (gpointer data)
   char *tempstr, *temp1str, *no_license_agreement, *str, buf[255], *share_dir;
   size_t len;
   FILE * fd;
-#if GTK_MAJOR_VERSION > 1
   GtkTextBuffer * textbuf;
   GtkTextIter iter;
   gint textlen;
-#endif
 
   share_dir = gftp_get_share_dir ();
   no_license_agreement = g_strdup_printf (_("Cannot find the license agreement file COPYING. Please make sure it is in either %s or in %s"), BASE_CONF_DIR, share_dir);
 
-#if GTK_MAJOR_VERSION == 1
-  dialog = gtk_dialog_new ();
-  gtk_window_set_title (GTK_WINDOW (dialog), _("About gFTP"));
-  gtk_container_border_width (GTK_CONTAINER
-			      (GTK_DIALOG (dialog)->action_area), 5);
-  gtk_box_set_homogeneous (GTK_BOX (GTK_DIALOG (dialog)->action_area), TRUE);
-#else
   dialog = gtk_dialog_new_with_buttons (_("About gFTP"), NULL, 0,
                                         GTK_STOCK_CLOSE,
                                         GTK_RESPONSE_CLOSE,
                                         NULL);
-#endif
+
   gtk_window_set_wmclass (GTK_WINDOW(dialog), "about", "gFTP");
   gtk_window_set_position (GTK_WINDOW (dialog), GTK_WIN_POS_MOUSE);
   gtk_container_border_width (GTK_CONTAINER (GTK_DIALOG (dialog)->vbox), 10);
@@ -512,21 +484,6 @@ about_dialog (gpointer data)
   gtk_box_pack_start (GTK_BOX (box), tempwid, TRUE, TRUE, 0);
   gtk_widget_show (tempwid);
 
-#if GTK_MAJOR_VERSION == 1
-  view = gtk_text_new (NULL, NULL);
-  gtk_text_set_editable (GTK_TEXT (view), FALSE);
-  gtk_text_set_word_wrap (GTK_TEXT (view), TRUE);
-
-  gtk_table_attach (GTK_TABLE (tempwid), view, 0, 1, 0, 1,
-                    GTK_FILL | GTK_EXPAND, GTK_FILL | GTK_EXPAND | GTK_SHRINK,
-                    0, 0);
-  gtk_widget_show (view);
-
-  vscroll = gtk_vscrollbar_new (GTK_TEXT (view)->vadj);
-  gtk_table_attach (GTK_TABLE (tempwid), vscroll, 1, 2, 0, 1,
-                    GTK_FILL, GTK_EXPAND | GTK_FILL | GTK_SHRINK, 0, 0);
-  gtk_widget_show (vscroll);
-#else
   view = gtk_text_view_new ();
   gtk_text_view_set_editable (GTK_TEXT_VIEW (view), FALSE);
   gtk_text_view_set_cursor_visible (GTK_TEXT_VIEW (view), FALSE);
@@ -546,28 +503,15 @@ about_dialog (gpointer data)
   gtk_widget_show (vscroll);
 
   textbuf = gtk_text_view_get_buffer (GTK_TEXT_VIEW (view));
-#endif
 
   label = gtk_label_new (_("License Agreement"));
   gtk_widget_show (label);
 
   gtk_notebook_append_page (GTK_NOTEBOOK (notebook), box, label);
 
-#if GTK_MAJOR_VERSION == 1
-  tempwid = gtk_button_new_with_label (_("  Close  "));
-  GTK_WIDGET_SET_FLAGS (tempwid, GTK_CAN_DEFAULT);
-  gtk_box_pack_start (GTK_BOX (GTK_DIALOG (dialog)->action_area), tempwid,
-		      FALSE, FALSE, 0);
-  gtk_signal_connect_object (GTK_OBJECT (tempwid), "clicked",
-			     GTK_SIGNAL_FUNC (gtk_widget_destroy),
-			     GTK_OBJECT (dialog));
-  gtk_widget_grab_default (tempwid);
-  gtk_widget_show (tempwid);
-#else
   g_signal_connect_swapped (GTK_OBJECT (dialog), "response",
                             G_CALLBACK (gtk_widget_destroy),
                             GTK_OBJECT (dialog));
-#endif
 
   tempstr = g_strconcat ("/usr/share/common-licenses/GPL", NULL);
   if (access (tempstr, F_OK) != 0)
@@ -582,14 +526,9 @@ about_dialog (gpointer data)
           tempstr = gftp_expand_path (NULL, BASE_CONF_DIR "/COPYING");
 	  if (access (tempstr, F_OK) != 0)
 	    {
-#if GTK_MAJOR_VERSION == 1
-	      gtk_text_insert (GTK_TEXT (view), NULL, NULL, NULL,
-			       no_license_agreement, -1);
-#else
               textlen = gtk_text_buffer_get_char_count (textbuf);
               gtk_text_buffer_get_iter_at_offset (textbuf, &iter, textlen);
               gtk_text_buffer_insert (textbuf, &iter, no_license_agreement, -1);
-#endif
 	      gtk_widget_show (dialog);
 	      return;
 	    }
@@ -598,14 +537,9 @@ about_dialog (gpointer data)
 
   if ((fd = fopen (tempstr, "r")) == NULL)
     {
-#if GTK_MAJOR_VERSION == 1
-      gtk_text_insert (GTK_TEXT (view), NULL, NULL, NULL,
-		       no_license_agreement, -1);
-#else
       textlen = gtk_text_buffer_get_char_count (textbuf);
       gtk_text_buffer_get_iter_at_offset (textbuf, &iter, textlen);
       gtk_text_buffer_insert (textbuf, &iter, no_license_agreement, -1);
-#endif
       gtk_widget_show (dialog);
       g_free (tempstr);
       return;
@@ -616,13 +550,9 @@ about_dialog (gpointer data)
   while ((len = fread (buf, 1, sizeof (buf) - 1, fd)))
     {
       buf[len] = '\0';
-#if GTK_MAJOR_VERSION == 1
-      gtk_text_insert (GTK_TEXT (view), NULL, NULL, NULL, buf, -1);
-#else
       textlen = gtk_text_buffer_get_char_count (textbuf);
       gtk_text_buffer_get_iter_at_offset (textbuf, &iter, textlen);
       gtk_text_buffer_insert (textbuf, &iter, buf, -1);
-#endif
     }
   fclose (fd);
   gtk_widget_show (dialog);

--- a/src/gtk/options_dialog.c
+++ b/src/gtk/options_dialog.c
@@ -228,36 +228,22 @@ _textcomboedt_toggle (GtkList * list, GtkWidget * child, gpointer data)
   gftp_textcomboedt_data * tedata;
   char *insert_text;
   int num, isedit;
-#if GTK_MAJOR_VERSION > 1
   GtkTextIter iter, iter2;
   GtkTextBuffer * textbuf;
   gint len;
-#endif
 
   widdata = data;
   tedata = widdata->cv->listdata;
 
   num = gtk_list_child_position (list, child);
   isedit = tedata[num].flags & GFTP_TEXTCOMBOEDT_EDITABLE;
-#if GTK_MAJOR_VERSION == 1
-  gtk_text_set_editable (GTK_TEXT (widdata->text), isedit);
-#else
   gtk_text_view_set_editable (GTK_TEXT_VIEW (widdata->text), isedit);
-#endif
 
   if (isedit)
     insert_text = widdata->custom_edit_value;
   else
     insert_text = tedata[num].text;
 
-#if GTK_MAJOR_VERSION == 1
-  gtk_text_set_point (GTK_TEXT (widdata->text), 0);
-  gtk_text_forward_delete (GTK_TEXT (widdata->text),
-			   gtk_text_get_length (GTK_TEXT (widdata->text)));
-
-  gtk_text_insert (GTK_TEXT (widdata->text), NULL, NULL, NULL, 
-                   insert_text, -1);
-#else
   textbuf = gtk_text_view_get_buffer (GTK_TEXT_VIEW (widdata->text));
   len = gtk_text_buffer_get_char_count (textbuf);
   gtk_text_buffer_get_iter_at_offset (textbuf, &iter, 0);
@@ -267,7 +253,6 @@ _textcomboedt_toggle (GtkList * list, GtkWidget * child, gpointer data)
   len = gtk_text_buffer_get_char_count (textbuf);
   gtk_text_buffer_get_iter_at_offset (textbuf, &iter, len);
   gtk_text_buffer_insert (textbuf, &iter, insert_text, -1);
-#endif
 }
 
 
@@ -395,14 +380,6 @@ _print_option_type_textcomboedt (gftp_config_vars * cv, void *user_data, void *v
   gtk_table_resize (GTK_TABLE (option_data->table), 
                                option_data->tbl_row_num, 2);
 
-#if GTK_MAJOR_VERSION == 1
-  textwid = gtk_text_new (NULL, NULL);
-  gtk_widget_set_size_request (textwid, -1, 75);
-  gtk_table_attach_defaults (GTK_TABLE (option_data->table), textwid, 0, 2,
-                             option_data->tbl_row_num - 1, 
-                             option_data->tbl_row_num);
-  gtk_widget_show (textwid);
-#else
   box = gtk_hbox_new (FALSE, 0);
   gtk_table_attach_defaults (GTK_TABLE (option_data->table), box, 0, 2,
                     	     option_data->tbl_row_num - 1, 
@@ -427,7 +404,6 @@ _print_option_type_textcomboedt (gftp_config_vars * cv, void *user_data, void *v
   textwid = gtk_text_view_new ();
   gtk_container_add (GTK_CONTAINER (tempwid), GTK_WIDGET (textwid));
   gtk_widget_show (textwid);
-#endif
 
   widdata = g_malloc0 (sizeof (*widdata));
   widdata->combo = combo;
@@ -462,40 +438,19 @@ _save_option_type_textcomboedt (gftp_config_vars * cv, void *user_data)
   gftp_options_dialog_data * option_data;
   char *newstr, *proxy_config;
   int freeit;
-#if GTK_MAJOR_VERSION == 1
-  char tmp[128];
-#else
   GtkTextBuffer * textbuf;
   GtkTextIter iter, iter2;
   size_t len;
-#endif
 
   option_data = user_data;
   widdata = cv->user_data;
 
-#if GTK_MAJOR_VERSION == 1
-  /*
-     GTK_TEXT uses wchar_t instead of char in environment of multibyte encoding
-     locale (ex Japanese),  so we must convert from wide character 
-     to multibyte charator....   Yasuyuki Furukawa (yasu@on.cs.keio.ac.jp)
-   */
-  if (GTK_TEXT (widdata->text)->use_wchar)
-    {
-      wcstombs (tmp, (wchar_t *) GTK_TEXT (widdata->text)->text.wc, sizeof (tmp));
-      newstr = tmp;
-    }
-  else
-    newstr = (char *) GTK_TEXT (widdata->text)->text.ch; 
-
-  freeit = 0;
-#else
   textbuf = gtk_text_view_get_buffer (GTK_TEXT_VIEW (widdata->text));
   len = gtk_text_buffer_get_char_count (textbuf);
   gtk_text_buffer_get_iter_at_offset (textbuf, &iter, 0);
   gtk_text_buffer_get_iter_at_offset (textbuf, &iter2, len);
   newstr = gtk_text_buffer_get_text (textbuf, &iter, &iter2, 0);
   freeit = 1;
-#endif
 
   proxy_config = _gftp_convert_from_newlines (newstr);
 
@@ -751,7 +706,6 @@ apply_changes (GtkWidget * widget, gpointer data)
 }
 
 
-#if GTK_MAJOR_VERSION > 1
 static void
 options_action (GtkWidget * widget, gint response, gpointer user_data)
 {
@@ -765,7 +719,6 @@ options_action (GtkWidget * widget, gint response, gpointer user_data)
         gtk_widget_destroy (widget);
     }
 }
-#endif
 
 
 static void
@@ -870,7 +823,6 @@ add_ok (GtkWidget * widget, gpointer data)
 }
 
 
-#if GTK_MAJOR_VERSION > 1
 static void
 proxyhosts_action (GtkWidget * widget, gint response, gpointer user_data)
 {
@@ -883,7 +835,6 @@ proxyhosts_action (GtkWidget * widget, gint response, gpointer user_data)
         gtk_widget_destroy (widget);
     }
 }
-#endif
 
 
 static void
@@ -953,16 +904,7 @@ add_proxy_host (GtkWidget * widget, gpointer data)
     }
 
   title = hosts ? _("Edit Host") : _("Add Host");
-#if GTK_MAJOR_VERSION == 1
-  dialog = gtk_dialog_new ();
-  gtk_window_set_title (GTK_WINDOW (dialog), title);
-  gtk_container_border_width (GTK_CONTAINER
-			      (GTK_DIALOG (dialog)->action_area), 5);
-  gtk_box_set_spacing (GTK_BOX (GTK_DIALOG (dialog)->action_area), 15);
-  gtk_box_set_homogeneous (GTK_BOX (GTK_DIALOG (dialog)->action_area), TRUE);
-  gtk_grab_add (dialog);
-  gtk_container_border_width (GTK_CONTAINER (GTK_DIALOG (dialog)->vbox), 10);
-#else
+
   dialog = gtk_dialog_new_with_buttons (title, NULL, 0,
                                         GTK_STOCK_CANCEL,
                                         GTK_RESPONSE_CANCEL,
@@ -972,12 +914,11 @@ add_proxy_host (GtkWidget * widget, gpointer data)
   gtk_container_set_border_width (GTK_CONTAINER (dialog), 5);
   gtk_dialog_set_has_separator (GTK_DIALOG (dialog), FALSE);
   gtk_window_set_resizable (GTK_WINDOW (dialog), FALSE);
-#endif
+
   gtk_box_set_spacing (GTK_BOX (GTK_DIALOG (dialog)->vbox), 2);
   gtk_window_set_wmclass (GTK_WINDOW(dialog), "hostinfo", "Gftp");
   gtk_window_set_position (GTK_WINDOW (dialog), GTK_WIN_POS_MOUSE);
 
-#if GTK_MAJOR_VERSION > 1
   if (gftp_icon != NULL)
     {
       if ((tempstr = get_xpm_path (gftp_icon->filename, 0)) != NULL)
@@ -986,7 +927,6 @@ add_proxy_host (GtkWidget * widget, gpointer data)
 	 g_free (tempstr);
         }
     }
-#endif
 
   vbox = gtk_vbox_new (FALSE, 6);
   gtk_container_border_width (GTK_CONTAINER (vbox), 5);
@@ -997,11 +937,8 @@ add_proxy_host (GtkWidget * widget, gpointer data)
   gtk_box_pack_start (GTK_BOX (vbox), box, FALSE, FALSE, 0);
   gtk_widget_show (box);
   
-#if GTK_MAJOR_VERSION == 1
-  tempwid = gtk_label_new (_("Type:"));
-#else
   tempwid = gtk_label_new_with_mnemonic (_("_Type:"));
-#endif
+
   gtk_misc_set_alignment (GTK_MISC (tempwid), 0, 0);
   gtk_box_pack_start (GTK_BOX (box), tempwid, FALSE, FALSE, 0);
   gtk_widget_show (tempwid);
@@ -1019,9 +956,8 @@ add_proxy_host (GtkWidget * widget, gpointer data)
                                            _("Network"));
   gtk_signal_connect (GTK_OBJECT (nradio), "toggled",
 		      GTK_SIGNAL_FUNC (add_toggle), NULL);
-#if GTK_MAJOR_VERSION > 1
+
   gtk_label_set_mnemonic_widget (GTK_LABEL (tempwid), nradio);
-#endif
 
   gtk_box_pack_start (GTK_BOX (rbox), nradio, TRUE, TRUE, 0);
   gtk_widget_show (nradio);
@@ -1042,11 +978,8 @@ add_proxy_host (GtkWidget * widget, gpointer data)
   gtk_box_pack_start (GTK_BOX (box), table, FALSE, FALSE, 0);
   gtk_widget_show (table);
 
-#if GTK_MAJOR_VERSION == 1
-  tempwid = gtk_label_new (_("Network Address"));
-#else
   tempwid = gtk_label_new_with_mnemonic (_("_Network address:"));
-#endif
+
   network_label = tempwid;
   gtk_misc_set_alignment (GTK_MISC (tempwid), 0, 0.5);
   gtk_table_attach_defaults (GTK_TABLE (table), tempwid, 0, 1, 0, 1);
@@ -1058,9 +991,7 @@ add_proxy_host (GtkWidget * widget, gpointer data)
 
   network1 = gtk_entry_new ();
   gtk_widget_set_size_request (network1, 36, -1);
-#if GTK_MAJOR_VERSION > 1
   gtk_label_set_mnemonic_widget (GTK_LABEL (tempwid), network1);
-#endif
 
   gtk_box_pack_start (GTK_BOX (box), network1, TRUE, TRUE, 0);
   gtk_widget_show (network1);
@@ -1083,12 +1014,9 @@ add_proxy_host (GtkWidget * widget, gpointer data)
   gtk_box_pack_start (GTK_BOX (box), network4, TRUE, TRUE, 0);
   gtk_widget_show (network4);
 
-#if GTK_MAJOR_VERSION == 1
-  tempwid = gtk_label_new (_("Netmask"));
-#else
   tempwid = gtk_label_new_with_mnemonic (_("N_etmask:"));
-#endif
   netmask_label = tempwid;
+
   gtk_misc_set_alignment (GTK_MISC (tempwid), 0, 0.5);
   gtk_table_attach_defaults (GTK_TABLE (table), tempwid, 0, 1, 1, 2);
   gtk_widget_show (tempwid);
@@ -1099,9 +1027,7 @@ add_proxy_host (GtkWidget * widget, gpointer data)
 
   netmask1 = gtk_entry_new ();
   gtk_widget_set_size_request (netmask1, 36, -1);
-#if GTK_MAJOR_VERSION > 1
   gtk_label_set_mnemonic_widget (GTK_LABEL (tempwid), netmask1);
-#endif
 
   gtk_box_pack_start (GTK_BOX (box), netmask1, TRUE, TRUE, 0);
   gtk_widget_show (netmask1);
@@ -1132,11 +1058,8 @@ add_proxy_host (GtkWidget * widget, gpointer data)
   gtk_box_pack_start (GTK_BOX (box), tempwid, FALSE, FALSE, 0);
   gtk_widget_show (tempwid);
 
-#if GTK_MAJOR_VERSION == 1
-  tempwid = gtk_label_new (_("Domain"));
-#else
   tempwid = gtk_label_new_with_mnemonic (_("_Domain:"));
-#endif
+
   domain_label = tempwid;
   gtk_misc_set_alignment (GTK_MISC (tempwid), 0, 0.5);
   gtk_box_pack_start (GTK_BOX (box), tempwid, FALSE, FALSE, 0);
@@ -1145,9 +1068,7 @@ add_proxy_host (GtkWidget * widget, gpointer data)
   new_proxy_domain = gtk_entry_new ();
   gtk_box_pack_start (GTK_BOX (box), new_proxy_domain, TRUE, TRUE, 0);
   gtk_widget_show (new_proxy_domain);
-#if GTK_MAJOR_VERSION > 1
   gtk_label_set_mnemonic_widget (GTK_LABEL (tempwid), new_proxy_domain);
-#endif
 
   if (!hosts || !hosts->domain)
     {
@@ -1200,30 +1121,8 @@ add_proxy_host (GtkWidget * widget, gpointer data)
 	}
     }
 
-#if GTK_MAJOR_VERSION == 1
-  tempwid = gtk_button_new_with_label (_("OK"));
-  GTK_WIDGET_SET_FLAGS (tempwid, GTK_CAN_DEFAULT);
-  gtk_box_pack_start (GTK_BOX (GTK_DIALOG (dialog)->action_area), tempwid,
-		      TRUE, TRUE, 0);
-  gtk_signal_connect (GTK_OBJECT (tempwid), "clicked",
-		      GTK_SIGNAL_FUNC (add_ok), (gpointer) templist);
-  gtk_signal_connect_object (GTK_OBJECT (tempwid), "clicked",
-			     GTK_SIGNAL_FUNC (gtk_widget_destroy),
-			     GTK_OBJECT (dialog));
-  gtk_widget_show (tempwid);
-
-  tempwid = gtk_button_new_with_label (_("  Cancel  "));
-  GTK_WIDGET_SET_FLAGS (tempwid, GTK_CAN_DEFAULT);
-  gtk_box_pack_start (GTK_BOX (GTK_DIALOG (dialog)->action_area), tempwid,
-		      TRUE, TRUE, 0);
-  gtk_signal_connect_object (GTK_OBJECT (tempwid), "clicked",
-			     GTK_SIGNAL_FUNC (gtk_widget_destroy),
-			     GTK_OBJECT (dialog));
-  gtk_widget_show (tempwid);
-#else
   g_signal_connect (GTK_OBJECT (dialog), "response",
                     G_CALLBACK (proxyhosts_action), NULL);
-#endif
 
   gtk_widget_show (dialog);
 }
@@ -1272,20 +1171,15 @@ make_proxy_hosts_tab (GtkWidget * notebook)
   gtk_box_pack_start (GTK_BOX (box), hbox, FALSE, FALSE, 0);
   gtk_widget_show (hbox);
 
-#if GTK_MAJOR_VERSION == 1
-  tempwid = gtk_button_new_with_label (_("Add"));
-#else
   tempwid = gtk_button_new_from_stock (GTK_STOCK_ADD);
-#endif
+
   GTK_WIDGET_SET_FLAGS (tempwid, GTK_CAN_DEFAULT);
   gtk_box_pack_start (GTK_BOX (hbox), tempwid, TRUE, TRUE, 0);
   gtk_signal_connect (GTK_OBJECT (tempwid), "clicked",
 		      GTK_SIGNAL_FUNC (add_proxy_host), NULL);
   gtk_widget_show (tempwid);
 
-#if GTK_MAJOR_VERSION == 1
-  tempwid = gtk_button_new_with_label (_("Edit"));
-#elif GTK_MAJOR_VERSION == 2 && GTK_MINOR_VERSION < 5
+#if GTK_MAJOR_VERSION == 2 && GTK_MINOR_VERSION < 5
   tempwid = gtk_button_new_with_mnemonic (_("_Edit"));
 #else
   tempwid = gtk_button_new_from_stock (GTK_STOCK_EDIT);
@@ -1297,11 +1191,8 @@ make_proxy_hosts_tab (GtkWidget * notebook)
 		      GTK_SIGNAL_FUNC (add_proxy_host), (gpointer) 1);
   gtk_widget_show (tempwid);
 
-#if GTK_MAJOR_VERSION == 1
-  tempwid = gtk_button_new_with_label (_("Delete"));
-#else
   tempwid = gtk_button_new_from_stock (GTK_STOCK_DELETE);
-#endif
+
   delete_button = tempwid;
   GTK_WIDGET_SET_FLAGS (tempwid, GTK_CAN_DEFAULT);
   gtk_box_pack_start (GTK_BOX (hbox), tempwid, TRUE, TRUE, 0);
@@ -1355,19 +1246,9 @@ options_dialog (gpointer data)
   GList * templist;
   void *value;
   int i;
-#if GTK_MAJOR_VERSION == 1
-  GtkWidget * tempwid;
-#endif
 
   gftp_option_data = _init_option_data ();
 
-#if GTK_MAJOR_VERSION == 1
-  gftp_option_data->dialog = gtk_dialog_new ();
-  gtk_window_set_title (GTK_WINDOW (gftp_option_data->dialog), _("Options"));
-  gtk_container_border_width (GTK_CONTAINER (GTK_DIALOG (gftp_option_data->dialog)->action_area), 5);
-  gtk_box_set_spacing (GTK_BOX (GTK_DIALOG (gftp_option_data->dialog)->action_area), 15);
-  gtk_box_set_homogeneous (GTK_BOX (GTK_DIALOG (gftp_option_data->dialog)->action_area), TRUE);
-#else
   gftp_option_data->dialog = gtk_dialog_new_with_buttons (_("Options"), NULL, 0,
                                         GTK_STOCK_CANCEL,
                                         GTK_RESPONSE_CANCEL,
@@ -1377,14 +1258,12 @@ options_dialog (gpointer data)
   gtk_container_set_border_width (GTK_CONTAINER (gftp_option_data->dialog), 5);
   gtk_dialog_set_has_separator (GTK_DIALOG (gftp_option_data->dialog), FALSE);
   gtk_window_set_resizable (GTK_WINDOW (gftp_option_data->dialog), FALSE);
-#endif
+
   gtk_window_set_wmclass (GTK_WINDOW(gftp_option_data->dialog),
                           "options", "gFTP");
   gtk_window_set_position (GTK_WINDOW (gftp_option_data->dialog),
                            GTK_WIN_POS_MOUSE);
-#if GTK_MAJOR_VERSION == 1
-  gtk_container_border_width (GTK_CONTAINER (GTK_DIALOG (gftp_option_data->dialog)->vbox), 10);
-#endif
+
   gtk_box_set_spacing (GTK_BOX (GTK_DIALOG (gftp_option_data->dialog)->vbox), 2);
   gtk_widget_realize (gftp_option_data->dialog);
 
@@ -1399,9 +1278,7 @@ options_dialog (gpointer data)
   gtk_box_pack_start (GTK_BOX (GTK_DIALOG (gftp_option_data->dialog)->vbox), 
                       gftp_option_data->notebook, TRUE, TRUE, 0);
   gtk_widget_show (gftp_option_data->notebook);
-#if GTK_MAJOR_VERSION > 1
   gtk_container_border_width (GTK_CONTAINER (gftp_option_data->notebook), 5);
-#endif
 
   cv = gftp_options_list->data;
   gftp_option_data->last_option = cv[0].otype;
@@ -1432,41 +1309,8 @@ options_dialog (gpointer data)
 
   make_proxy_hosts_tab (gftp_option_data->notebook);
 
-#if GTK_MAJOR_VERSION == 1
-  tempwid = gtk_button_new_with_label (_("OK"));
-  GTK_WIDGET_SET_FLAGS (tempwid, GTK_CAN_DEFAULT);
-  gtk_box_pack_start (GTK_BOX (GTK_DIALOG (gftp_option_data->dialog)->action_area), 
-                      tempwid, TRUE, TRUE, 0);
-  gtk_signal_connect (GTK_OBJECT (tempwid), "clicked",
-                      GTK_SIGNAL_FUNC (apply_changes), NULL);
-  gtk_signal_connect_object (GTK_OBJECT (tempwid), "clicked",
-                             GTK_SIGNAL_FUNC (gtk_widget_destroy),
-                             GTK_OBJECT (gftp_option_data->dialog));
-  gtk_widget_show (tempwid);
-
-  tempwid = gtk_button_new_with_label (_("  Cancel  "));
-  GTK_WIDGET_SET_FLAGS (tempwid, GTK_CAN_DEFAULT);
-  gtk_box_pack_start (GTK_BOX (GTK_DIALOG (gftp_option_data->dialog)->action_area), 
-                      tempwid, TRUE, TRUE, 0);
-  gtk_signal_connect (GTK_OBJECT (tempwid), "clicked",
-                      GTK_SIGNAL_FUNC (clean_old_changes), NULL);
-  gtk_signal_connect_object (GTK_OBJECT (tempwid), "clicked",
-                             GTK_SIGNAL_FUNC (gtk_widget_destroy),
-                             GTK_OBJECT (gftp_option_data->dialog));
-  gtk_widget_show (tempwid);
-
-  tempwid = gtk_button_new_with_label (_("Apply"));
-  GTK_WIDGET_SET_FLAGS (tempwid, GTK_CAN_DEFAULT);
-  gtk_box_pack_start (GTK_BOX (GTK_DIALOG (gftp_option_data->dialog)->action_area), 
-                      tempwid, TRUE, TRUE, 0);
-  gtk_signal_connect (GTK_OBJECT (tempwid), "clicked",
-                      GTK_SIGNAL_FUNC (apply_changes), NULL);
-  gtk_widget_grab_default (tempwid);
-  gtk_widget_show (tempwid);
-#else
   g_signal_connect (GTK_OBJECT (gftp_option_data->dialog), "response",
                     G_CALLBACK (options_action), NULL);
-#endif
 
   gtk_widget_show (gftp_option_data->dialog);
 }

--- a/src/gtk/view_dialog.c
+++ b/src/gtk/view_dialog.c
@@ -220,10 +220,8 @@ view_file (char *filename, int fd, unsigned int viewedit, unsigned int del_file,
   int doclose;
   ssize_t n;
   char * non_utf8;
-#if GTK_MAJOR_VERSION > 1
   GtkTextBuffer * textbuf;
   GtkTextIter iter;
-#endif
 
   doclose = 1;
   stlen = strlen (filename);
@@ -313,18 +311,11 @@ view_file (char *filename, int fd, unsigned int viewedit, unsigned int del_file,
   if (non_utf8 != filename && non_utf8)
     g_free (non_utf8);
 
-#if GTK_MAJOR_VERSION == 1
-  dialog = gtk_dialog_new ();
-  gtk_window_set_title (GTK_WINDOW (dialog), filename);
-  gtk_container_border_width (GTK_CONTAINER (GTK_DIALOG (dialog)->action_area),
-                              5);
-  gtk_box_set_homogeneous (GTK_BOX (GTK_DIALOG (dialog)->action_area), TRUE);
-#else
   dialog = gtk_dialog_new_with_buttons (filename, NULL, 0,
                                         GTK_STOCK_CLOSE,
                                         GTK_RESPONSE_CLOSE,
                                         NULL);
-#endif
+
   gtk_window_set_wmclass (GTK_WINDOW(dialog), "fileview", "gFTP");
   gtk_container_border_width (GTK_CONTAINER (GTK_DIALOG (dialog)->vbox), 5);
   gtk_box_set_spacing (GTK_BOX (GTK_DIALOG (dialog)->vbox), 5);
@@ -340,23 +331,6 @@ view_file (char *filename, int fd, unsigned int viewedit, unsigned int del_file,
   table = gtk_table_new (1, 2, FALSE);
   gtk_box_pack_start (GTK_BOX (GTK_DIALOG (dialog)->vbox), table, TRUE, TRUE, 0);
 
-#if GTK_MAJOR_VERSION == 1
-  view = gtk_text_new (NULL, NULL);
-  gtk_text_set_editable (GTK_TEXT (view), FALSE);
-  gtk_text_set_word_wrap (GTK_TEXT (view), TRUE);
-
-  gtk_table_attach (GTK_TABLE (table), view, 0, 1, 0, 1,
-		    GTK_FILL | GTK_EXPAND, GTK_FILL | GTK_EXPAND | GTK_SHRINK,
-		    0, 0);
-  gtk_widget_show (view);
-
-  tempwid = gtk_vscrollbar_new (GTK_TEXT (view)->vadj);
-  gtk_table_attach (GTK_TABLE (table), tempwid, 1, 2, 0, 1,
-		    GTK_FILL, GTK_EXPAND | GTK_FILL | GTK_SHRINK, 0, 0);
-  gtk_widget_show (tempwid);
-
-  vadj = GTK_TEXT (view)->vadj;
-#else
   view = gtk_text_view_new ();
   gtk_text_view_set_editable (GTK_TEXT_VIEW (view), FALSE);
   gtk_text_view_set_cursor_visible (GTK_TEXT_VIEW (view), FALSE);
@@ -376,35 +350,20 @@ view_file (char *filename, int fd, unsigned int viewedit, unsigned int del_file,
   gtk_widget_show (tempwid);
 
   vadj = gtk_scrolled_window_get_vadjustment (GTK_SCROLLED_WINDOW (tempwid));
-#endif
   gtk_widget_set_size_request (table, 500, 400);
   gtk_widget_show (table);
 
-#if GTK_MAJOR_VERSION == 1
-  tempwid = gtk_button_new_with_label (_("  Close  "));
-  gtk_box_pack_start (GTK_BOX (GTK_DIALOG (dialog)->action_area), tempwid,
-		      FALSE, FALSE, 0);
-  gtk_signal_connect_object (GTK_OBJECT (tempwid), "clicked",
-			     GTK_SIGNAL_FUNC (gtk_widget_destroy),
-			     GTK_OBJECT (dialog));
-  gtk_widget_show (tempwid);
-#else
   g_signal_connect_swapped (GTK_OBJECT (dialog), "response",
                             G_CALLBACK (gtk_widget_destroy),
                             GTK_OBJECT (dialog));
-#endif
 
   buf[sizeof (buf) - 1] = '\0';
   while ((n = read (fd, buf, sizeof (buf) - 1)) > 0)
     {
       buf[n] = '\0';
-#if GTK_MAJOR_VERSION == 1
-      gtk_text_insert (GTK_TEXT (view), NULL, NULL, NULL, buf, -1);
-#else
       textbuf = gtk_text_view_get_buffer (GTK_TEXT_VIEW (view));
       gtk_text_buffer_get_iter_at_offset (textbuf, &iter, -1);
       gtk_text_buffer_insert (textbuf, &iter, buf, -1);
-#endif
     }
 
   if (doclose)


### PR DESCRIPTION
This patch should remove all of the legacy GTK Version 1 support. Since it is rather large, I've broken this up in to separate commits for each file to make it less trouble to review in case I missed something. 

As part of this patch, I have explicitly set the glib check for higher than 2.31.0 due to the gthread api changes.

It compiles and still works for me on OS X but your milage may vary.