### PR TITLE
Modify toolbar image loading code to use gtk_image api to support *.xpm or *.png

### DIFF
--- a/src/gtk/gftp-gtk.c
+++ b/src/gtk/gftp-gtk.c
@@ -469,7 +469,7 @@ CreateConnectToolbar (GtkWidget * parent)
 
   openurl_tooltip = gtk_tooltips_new ();
 
-  tempwid = toolbar_pixmap (parent, "connect.xpm");
+  tempwid = toolbar_image (parent, "connect.xpm");
   openurl_btn = gtk_button_new ();
   gtk_container_add (GTK_CONTAINER (openurl_btn), tempwid);
   gtk_signal_connect_object (GTK_OBJECT (openurl_btn), "clicked",

--- a/src/gtk/gftp-gtk.h
+++ b/src/gtk/gftp-gtk.h
@@ -317,7 +317,7 @@ void update_window_info				( void );
 
 void update_window				( gftp_window_data * wdata );
 
-GtkWidget * toolbar_pixmap			( GtkWidget * widget,
+GtkWidget * toolbar_image			( GtkWidget * widget,
 						  char *filename );
 
 gftp_graphic * open_xpm				( GtkWidget * widget,
@@ -383,7 +383,7 @@ int progress_timeout 				( gpointer data );
 
 void display_cached_logs			( void );
 
-char * get_xpm_path 				( char *filename, 
+char * get_image_path 				( char *filename, 
 						  int quit_on_err );
 
 /* options_dialog.c */

--- a/src/gtk/menu-items.c
+++ b/src/gtk/menu-items.c
@@ -454,7 +454,7 @@ about_dialog (gpointer data)
   gtk_container_border_width (GTK_CONTAINER (box), 10);
   gtk_widget_show (box);
 
-  tempwid = toolbar_pixmap (dialog, "gftp-logo.xpm");
+  tempwid = toolbar_image (dialog, "gftp-logo.xpm");
   gtk_box_pack_start (GTK_BOX (box), tempwid, FALSE, FALSE, 0);
   gtk_widget_show (tempwid);
 

--- a/src/gtk/misc-gtk.c
+++ b/src/gtk/misc-gtk.c
@@ -335,21 +335,19 @@ update_window (gftp_window_data * wdata)
 
 
 GtkWidget *
-toolbar_pixmap (GtkWidget * widget, char *filename)
+toolbar_image (GtkWidget * widget, char *filename)
 {
   gftp_graphic * graphic;
   GtkWidget *pix;
+  char *exfile;
 
   if (filename == NULL || *filename == '\0')
     return (NULL);
 
-  graphic = open_xpm (widget, filename);
+  if ((exfile = get_image_path (filename, 0)) == NULL)
+    return (NULL);
 
-  if (graphic == NULL)
-    return (NULL);
-    
-  if ((pix = gtk_pixmap_new (graphic->pixmap, graphic->bitmap)) == NULL)
-    return (NULL);
+  pix = gtk_image_new_from_file(exfile);
 
   gtk_widget_show (pix);
   return (pix);
@@ -368,7 +366,7 @@ open_xpm (GtkWidget * widget, char *filename)
 
   style = gtk_widget_get_style (widget);
 
-  if ((exfile = get_xpm_path (filename, 0)) == NULL)
+  if ((exfile = get_image_path (filename, 0)) == NULL)
     return (NULL);
 
   graphic = g_malloc0 (sizeof (*graphic));
@@ -434,7 +432,6 @@ gftp_get_pixmap (GtkWidget * widget, char *filename, GdkPixmap ** pix,
   *pix = graphic->pixmap;
   *bitmap = graphic->bitmap;
 }
-
 
 int
 check_status (char *name, gftp_window_data *wdata,
@@ -1050,9 +1047,8 @@ display_cached_logs (void)
   pthread_mutex_unlock (&log_mutex);
 }
 
-
 char *
-get_xpm_path (char *filename, int quit_on_err)
+get_image_path (char *filename, int quit_on_err)
 {
   char *tempstr, *exfile, *share_dir;
 

--- a/src/gtk/options_dialog.c
+++ b/src/gtk/options_dialog.c
@@ -921,7 +921,7 @@ add_proxy_host (GtkWidget * widget, gpointer data)
 
   if (gftp_icon != NULL)
     {
-      if ((tempstr = get_xpm_path (gftp_icon->filename, 0)) != NULL)
+      if ((tempstr = get_image_path (gftp_icon->filename, 0)) != NULL)
         {
          gtk_window_set_default_icon_from_file (tempstr, NULL);
 	 g_free (tempstr);


### PR DESCRIPTION
This is the first step towards removing the XPM specific stuff in favor of the GTK Image APIs and other newer graphics magic,.

I've tested this in my local tree by converting connect.xpm to a png image and modifying the line

gftp-gtk.c:  tempwid = toolbar_image (parent, "connect.xpm");

to

gftp-gtk.c:  tempwid = toolbar_image (parent, "connect.png");

In my local tree as well as deleting the connect.xpm and it still functions. I've also tested with restoring the xpm so it should be 100% safe.

For now, we will leave the call as connect.xpm and will convert all of the images in one shot.

Changelog:

Rename some of the icon graphics functions to be a little more generic
Modify the toolbar image loading functions to use the gtk_image api
   (This has the benefit of allowing us to load either a *.xpm or *.png)