### PR TITLE
Add small padding to transfer and message windows

### DIFF
--- a/src/gtk/gftp-gtk.c
+++ b/src/gtk/gftp-gtk.c
@@ -1027,6 +1027,9 @@ CreateFTPWindows (GtkWidget * ui)
   gtk_paned_pack2 (GTK_PANED (logpane), log_table, 1, 1);
   gtk_box_pack_start (GTK_BOX (mainvbox), logpane, TRUE, TRUE, 0);
 
+  gtk_container_set_border_width (GTK_CONTAINER (transfer_scroll), 5);
+  gtk_container_set_border_width (GTK_CONTAINER (tempwid), 5);
+
   gtk_widget_show_all (mainvbox);
   gftpui_show_or_hide_command ();
   return (mainvbox);


### PR DESCRIPTION
As discussed in PR #3 this is a minor cosmetic change that feels a bit more pleasing to the eye (at least mine). I am not sure how this will scale up or down on really large and small screens but it seems like a good value on the few monitors I've tested on under OS X.