### PR TITLE
gtk3 tooltips rewrite

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -203,19 +203,19 @@ if test "x$enable_gtkport" = "xyes" ; then
   if test "x$GFTP_GTK" = "x" ; then
     PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.31.0], found_glib20=1, found_glib20=0)
 
-    PKG_CHECK_MODULES(GTHREADS, gthread-2.0 >=  2.2.0, HAVE_GTHREADS="yes")
-    AC_SUBST(GTHREADS_CFLAGS)
-    AC_SUBST(GTHREADS_LIBS)
-    if test "x$HAVE_GTHREADS" = xyes ; then
-      GTHREAD_LIBS="-lgthread-2.0"
-    fi
-
     if test "x$enable_gtk20" = "xyes" ; then
       if test "x$enable_gtk30" = "xyes" ; then
         AC_MSG_ERROR(GTK 2.0 configuration cannot be built while experimental GTK 3.0 support is enabled)
       fi 
       dnl Test for gtk+-2.0
       PKG_CHECK_MODULES([GTK], [gtk+-2.0 >= 2.0.0], GFTP_GTK=gftp-gtk, AC_MSG_ERROR(You have GLIB 2.0 installed but I cannot find GTK+ 2.0. Run configure with --disable-gtk20 or install GTK+ 2.0))
+
+      PKG_CHECK_MODULES(GTHREADS, gthread-2.0 >=  2.2.0, HAVE_GTHREADS="yes")
+      AC_SUBST(GTHREADS_CFLAGS)
+      AC_SUBST(GTHREADS_LIBS)
+      if test "x$HAVE_GTHREADS" = xyes ; then
+        GTHREAD_LIBS="-lgthread-2.0"
+      fi
     fi
     if test "x$enable_gtk30" = "xyes" ; then
       if test "x$enable_gtk20" = "xyes" ; then 

--- a/src/gtk/gftp-gtk.c
+++ b/src/gtk/gftp-gtk.c
@@ -27,7 +27,6 @@ gftp_window_data window1, window2, *other_wdata, *current_wdata;
 GtkWidget * stop_btn, * hostedit, * useredit, * passedit, * portedit, * logwdw,
           * dlwdw, * optionmenu, * gftpui_command_widget, * download_left_arrow,
           * upload_right_arrow, * openurl_btn;
-GtkTooltips * openurl_tooltip;
 GtkAdjustment * logwdw_vadj;
 GtkTextMark * logwdw_textmark;
 int local_start, remote_start, trans_start;
@@ -466,8 +465,6 @@ CreateConnectToolbar (GtkWidget * parent)
   box = gtk_hbox_new (FALSE, 4);
   gtk_container_add (GTK_CONTAINER (toolbar), box);
   gtk_container_border_width (GTK_CONTAINER (box), 5);
-
-  openurl_tooltip = gtk_tooltips_new ();
 
   tempwid = toolbar_image (parent, "connect.xpm");
   openurl_btn = gtk_button_new ();

--- a/src/gtk/gftp-gtk.h
+++ b/src/gtk/gftp-gtk.h
@@ -181,7 +181,6 @@ extern GtkWidget * stop_btn, * hostedit, * useredit, * passedit,
                  * portedit, * logwdw, * dlwdw, * optionmenu,
                  * gftpui_command_widget, * download_left_arrow,
                  * upload_right_arrow, * openurl_btn;
-extern GtkTooltips * openurl_tooltip;
 extern GtkAdjustment * logwdw_vadj;
 #if GTK_MAJOR_VERSION > 1
 extern GtkTextMark * logwdw_textmark;

--- a/src/gtk/misc-gtk.c
+++ b/src/gtk/misc-gtk.c
@@ -204,12 +204,11 @@ update_window_info (void)
               j++;
             }
 
-          gtk_tooltips_set_tip (GTK_TOOLTIPS(openurl_tooltip), openurl_btn,
-                                _("Disconnect from the remote server"), NULL);
+          gtk_widget_set_tooltip_text (openurl_btn, _("Disconnect from the remote server"));
         }
       else
-        gtk_tooltips_set_tip (GTK_TOOLTIPS(openurl_tooltip), openurl_btn,
-                              _("Connect to the site specified in the host entry. If the host entry is blank, then a dialog is presented that will allow you to enter a URL."), NULL);
+        gtk_widget_set_tooltip_text (openurl_btn,
+                              _("Connect to the site specified in the host entry. If the host entry is blank, then a dialog is presented that will allow you to enter a URL."));
     }
 
   update_window (&window1);

--- a/src/gtk/options_dialog.c
+++ b/src/gtk/options_dialog.c
@@ -49,7 +49,6 @@ _setup_option (gftp_option_type_enum otype,
 static void *
 _gen_input_widget (gftp_options_dialog_data * option_data, char *label, char *tiptxt)
 {
-  GtkTooltips * tooltip;
   GtkWidget * tempwid;
 
   option_data->tbl_row_num++;
@@ -73,8 +72,7 @@ _gen_input_widget (gftp_options_dialog_data * option_data, char *label, char *ti
 
   if (tiptxt != NULL)
     {
-      tooltip = gtk_tooltips_new ();
-      gtk_tooltips_set_tip (GTK_TOOLTIPS(tooltip), tempwid, _(tiptxt), NULL);
+      gtk_widget_set_tooltip_text(tempwid,  _(tiptxt));
     }
 
   return (tempwid);
@@ -165,7 +163,6 @@ _print_option_type_textcombo (gftp_config_vars * cv, void *user_data, void *valu
   gftp_options_dialog_data * option_data;
   GtkWidget * tempwid, * combo;
   GList * widget_list;
-  GtkTooltips * tooltip;
   int selitem, i;
   char **clist;
 
@@ -196,8 +193,7 @@ _print_option_type_textcombo (gftp_config_vars * cv, void *user_data, void *valu
 
   if (cv->comment != NULL)
     {
-      tooltip = gtk_tooltips_new ();
-      gtk_tooltips_set_tip (GTK_TOOLTIPS(tooltip), combo, _(cv->comment), NULL);
+      gtk_widget_set_tooltip_text (combo, _(cv->comment));
     }
 
   return (combo);
@@ -334,7 +330,6 @@ _print_option_type_textcomboedt (gftp_config_vars * cv, void *user_data, void *v
   gftp_options_dialog_data * option_data;
   gftp_textcomboedt_data * tedata;
   int i, selitem, edititem;
-  GtkTooltips * tooltip;
   GList * widget_list;
   char *tempstr;
 
@@ -419,12 +414,8 @@ _print_option_type_textcomboedt (gftp_config_vars * cv, void *user_data, void *v
 
   if (cv->comment != NULL)
     {
-      tooltip = gtk_tooltips_new ();
-      gtk_tooltips_set_tip (GTK_TOOLTIPS(tooltip), combo, _(cv->comment), NULL);
-
-      tooltip = gtk_tooltips_new ();
-      gtk_tooltips_set_tip (GTK_TOOLTIPS(tooltip), textwid, _(cv->comment), 
-                            NULL);
+       gtk_widget_set_tooltip_text (textwid, _(cv->comment));
+       gtk_widget_set_tooltip_text (textwid, _(cv->comment)); 
     }
 
   return (widdata);
@@ -520,7 +511,6 @@ static void *
 _print_option_type_checkbox (gftp_config_vars * cv, void *user_data, void *value)
 {
   gftp_options_dialog_data * option_data;
-  GtkTooltips * tooltip;
   GtkWidget * tempwid;
 
   option_data = user_data;
@@ -549,9 +539,7 @@ _print_option_type_checkbox (gftp_config_vars * cv, void *user_data, void *value
 
   if (cv->comment != NULL)
     {
-      tooltip = gtk_tooltips_new ();
-      gtk_tooltips_set_tip (GTK_TOOLTIPS(tooltip), tempwid, _(cv->comment),
-                            NULL);
+      gtk_widget_set_tooltip_text (tempwid, _(cv->comment));
     }
 
   return (tempwid);


### PR DESCRIPTION
 - Move the gthreads check (there is no need to check for it on gtk3 systems)
 - Replace the Tooltips API calls wth the Tooltip API introduced in gtk 2.12
   (This is forward compatible with gtk3)

I have not been able to test this as I don't see a change in behavior on the mac, so I believe I may actually be missing tooltips on that platform. Can you apply to a Linux box and see if things still work as expected?

With this patch, we have a few more files that are now compatible with gtk3 but we still have a long way to go.