### PR TITLE
fix duplicated Ctrl+D shortcut (Bug#577505)

### DIFF
--- a/src/gtk/gftp-gtk.c
+++ b/src/gtk/gftp-gtk.c
@@ -305,7 +305,7 @@ CreateMenus (GtkWidget * parent)
     {N_("/Remote/tearoff"), NULL, 0, 0, MN_("<Tearoff>")},
     {N_("/Remote/_Open Location..."), "<control>O", openurl_dialog, 0,
 	MS_(GTK_STOCK_OPEN)},
-    {N_("/Remote/D_isconnect"), "<control>D", gftpui_disconnect, 0,
+    {N_("/Remote/D_isconnect"), "<control>I", gftpui_disconnect, 0,
 	MS_(GTK_STOCK_CLOSE)},
     {N_("/Remote/sep"), NULL, 0, 0, MN_("<Separator>")},
     {N_("/Remote/Change _Filespec..."), "<control>F", change_filespec, 0,


### PR DESCRIPTION
git-svn-id: svn://orbit.nmr.mgh.harvard.edu/var/lib/gforge/chroot/scmrepos/svn/gftp/trunk@1001 cc038f9a-a97d-43d7-a19c-d23a2e890d88