### PR TITLE
port number field can only fit two digits, need more, Bug#570149

### DIFF
--- a/src/gtk/gftp-gtk.c
+++ b/src/gtk/gftp-gtk.c
@@ -507,7 +507,7 @@ CreateConnectToolbar (GtkWidget * parent)
 
   portedit = gtk_combo_new ();
   gtk_combo_set_case_sensitive (GTK_COMBO (portedit), 1);
-  gtk_widget_set_size_request (portedit, 50, -1);
+  gtk_widget_set_size_request (portedit, 80, -1);
 
   gtk_signal_connect (GTK_OBJECT (GTK_COMBO (portedit)->entry), "activate",
 		      GTK_SIGNAL_FUNC (toolbar_hostedit), NULL);


### PR DESCRIPTION
git-svn-id: svn://orbit.nmr.mgh.harvard.edu/var/lib/gforge/chroot/scmrepos/svn/gftp/trunk@1018 cc038f9a-a97d-43d7-a19c-d23a2e890d88