### PR TITLE
gtkui: (window icon: use GdkPixbuf instead of GdkPixmap)

### DIFF
--- a/src/gtk/bookmarks.c
+++ b/src/gtk/bookmarks.c
@@ -834,12 +834,7 @@ edit_entry (gpointer data)
   gtk_container_border_width (GTK_CONTAINER (GTK_DIALOG (bm_dialog)->vbox), 10);
   gtk_widget_realize (bm_dialog);
 
-  if (gftp_icon != NULL)
-    {
-      gdk_window_set_icon (bm_dialog->window, NULL, gftp_icon->pixmap,
-                           gftp_icon->bitmap);
-      gdk_window_set_icon_name (bm_dialog->window, gftp_version);
-    }
+  set_window_icon(GTK_WINDOW(bm_dialog), NULL);
 
   notebook = gtk_notebook_new ();
   gtk_box_pack_start (GTK_BOX (GTK_DIALOG (bm_dialog)->vbox), notebook, TRUE,
@@ -1184,12 +1179,7 @@ edit_bookmarks (gpointer data)
                            GTK_WIN_POS_MOUSE);
   gtk_widget_realize (edit_bookmarks_dialog);
 
-  if (gftp_icon != NULL)
-    {
-      gdk_window_set_icon (edit_bookmarks_dialog->window, NULL,
-                           gftp_icon->pixmap, gftp_icon->bitmap);
-      gdk_window_set_icon_name (edit_bookmarks_dialog->window, gftp_version);
-    }
+  set_window_icon(GTK_WINDOW(edit_bookmarks_dialog), NULL);
 
   accel_group = gtk_accel_group_new ();
   ifactory = item_factory_new (GTK_TYPE_MENU_BAR, "<bookmarks>", accel_group,

--- a/src/gtk/chmod_dialog.c
+++ b/src/gtk/chmod_dialog.c
@@ -142,12 +142,7 @@ chmod_dialog (gpointer data)
   gtk_container_border_width (GTK_CONTAINER (GTK_DIALOG (dialog)->vbox), 10);
   gtk_widget_realize (dialog);
 
-  if (gftp_icon != NULL)
-    {
-      gdk_window_set_icon (dialog->window, NULL, gftp_icon->pixmap,
-                           gftp_icon->bitmap);
-      gdk_window_set_icon_name (dialog->window, gftp_version);
-    }
+  set_window_icon(GTK_WINDOW(dialog), NULL);
 
   tempwid = gtk_label_new (_("You can now adjust the attributes of your file(s)\nNote: Not all ftp servers support the chmod feature"));
   gtk_box_pack_start (GTK_BOX (GTK_DIALOG (dialog)->vbox), tempwid, FALSE,

--- a/src/gtk/gftp-gtk.c
+++ b/src/gtk/gftp-gtk.c
@@ -34,7 +34,6 @@ GHashTable * graphic_hash_table = NULL;
 GtkItemFactoryEntry * menus = NULL;
 GtkItemFactory * factory = NULL;
 pthread_mutex_t log_mutex = PTHREAD_MUTEX_INITIALIZER;
-gftp_graphic * gftp_icon;
 pthread_t main_thread_id;
 GList * viewedit_processes = NULL;
 
@@ -1365,13 +1364,7 @@ main (int argc, char **argv)
   gtk_window_set_policy (GTK_WINDOW (window), TRUE, TRUE, FALSE);
   gtk_widget_realize (window);
 
-  gftp_icon = open_xpm (window, "gftp.xpm");
-  if (gftp_icon != NULL)
-    {
-      gdk_window_set_icon (window->window, NULL, gftp_icon->pixmap,
-                           gftp_icon->bitmap);
-      gdk_window_set_icon_name (window->window, gftp_version);
-    }
+  set_window_icon(GTK_WINDOW(window), NULL);
 
   other_wdata = &window1;
   current_wdata = &window2;

--- a/src/gtk/gftp-gtk.h
+++ b/src/gtk/gftp-gtk.h
@@ -175,7 +175,6 @@ extern GHashTable * graphic_hash_table;
 extern GtkItemFactoryEntry * menus;
 extern GtkItemFactory * factory;
 extern pthread_mutex_t log_mutex;
-extern gftp_graphic * gftp_icon;
 extern pthread_t main_thread_id;
 extern GList * viewedit_processes;
 
@@ -369,6 +368,8 @@ void display_cached_logs			( void );
 
 char * get_image_path 				( char *filename, 
 						  int quit_on_err );
+
+void set_window_icon(GtkWindow *window, char *icon_name);
 
 /* options_dialog.c */
 void options_dialog 				( gpointer data );

--- a/src/gtk/menu-items.c
+++ b/src/gtk/menu-items.c
@@ -440,6 +440,7 @@ about_dialog (gpointer data)
     gtk_about_dialog_set_website(GTK_ABOUT_DIALOG(about_dlg), "http://www.gftp.org");
     gtk_about_dialog_set_authors(GTK_ABOUT_DIALOG(about_dlg), authors);
     gtk_about_dialog_set_translator_credits(GTK_ABOUT_DIALOG(about_dlg), translators);
+    set_window_icon(GTK_WINDOW(about_dlg), NULL);
 
     /* Display the dialog, wait for the user to click OK, and dismiss the dialog. */
     gtk_dialog_run(GTK_DIALOG(about_dlg));

--- a/src/gtk/misc-gtk.c
+++ b/src/gtk/misc-gtk.c
@@ -21,7 +21,6 @@
 
 static GtkWidget * statuswid;
 
-
 void
 remove_files_window (gftp_window_data * wdata)
 {
@@ -832,12 +831,7 @@ MakeEditDialog (char *diagtxt, char *infotxt, char *deftext, int passwd_item,
   gtk_grab_add (dialog);
   gtk_widget_realize (dialog);
 
-  if (gftp_icon != NULL)
-    {
-      gdk_window_set_icon (dialog->window, NULL, gftp_icon->pixmap,
-                           gftp_icon->bitmap);
-      gdk_window_set_icon_name (dialog->window, gftp_version);
-    }
+  set_window_icon(GTK_WINDOW(dialog), NULL);
 
   ddata->dialog = dialog;
 
@@ -905,12 +899,7 @@ MakeYesNoDialog (char *diagtxt, char *infotxt,
   gtk_grab_add (dialog);
   gtk_widget_realize (dialog);
 
-  if (gftp_icon != NULL)
-    {
-      gdk_window_set_icon (dialog->window, NULL, gftp_icon->pixmap,
-                           gftp_icon->bitmap);
-      gdk_window_set_icon_name (dialog->window, gftp_version);
-    }
+  set_window_icon(GTK_WINDOW(dialog), NULL);
 
   ddata->dialog = dialog;
 
@@ -1080,3 +1069,23 @@ get_image_path (char *filename, int quit_on_err)
   return (exfile);
 }
 
+
+void
+set_window_icon(GtkWindow *window, char *icon_name)
+{
+  GdkPixbuf *pixbuf;
+  char *img_path;
+  if (icon_name)
+    img_path = get_image_path (icon_name, 0);
+  else
+    img_path = get_image_path ("gftp.xpm", 0);
+  if (img_path) {
+    pixbuf = gdk_pixbuf_new_from_file(img_path, NULL);
+    g_free (img_path);
+    if (pixbuf) {
+      gtk_window_set_icon (window, pixbuf);
+      //gtk_window_set_icon_name (window, gftp_version);
+      g_object_unref(pixbuf);
+    }
+  }
+}

--- a/src/gtk/options_dialog.c
+++ b/src/gtk/options_dialog.c
@@ -907,15 +907,6 @@ add_proxy_host (GtkWidget * widget, gpointer data)
   gtk_window_set_wmclass (GTK_WINDOW(dialog), "hostinfo", "Gftp");
   gtk_window_set_position (GTK_WINDOW (dialog), GTK_WIN_POS_MOUSE);
 
-  if (gftp_icon != NULL)
-    {
-      if ((tempstr = get_image_path (gftp_icon->filename, 0)) != NULL)
-        {
-         gtk_window_set_default_icon_from_file (tempstr, NULL);
-	 g_free (tempstr);
-        }
-    }
-
   vbox = gtk_vbox_new (FALSE, 6);
   gtk_container_border_width (GTK_CONTAINER (vbox), 5);
   gtk_box_pack_start (GTK_BOX (GTK_DIALOG (dialog)->vbox), vbox, FALSE, FALSE, 0);
@@ -1255,12 +1246,7 @@ options_dialog (gpointer data)
   gtk_box_set_spacing (GTK_BOX (GTK_DIALOG (gftp_option_data->dialog)->vbox), 2);
   gtk_widget_realize (gftp_option_data->dialog);
 
-  if (gftp_icon != NULL)
-    {
-      gdk_window_set_icon (gftp_option_data->dialog->window, NULL,
-                           gftp_icon->pixmap, gftp_icon->bitmap);
-      gdk_window_set_icon_name (gftp_option_data->dialog->window, gftp_version);
-    }
+  set_window_icon(GTK_WINDOW(gftp_option_data->dialog), NULL);
 
   gftp_option_data->notebook = gtk_notebook_new ();
   gtk_box_pack_start (GTK_BOX (GTK_DIALOG (gftp_option_data->dialog)->vbox), 

--- a/src/gtk/view_dialog.c
+++ b/src/gtk/view_dialog.c
@@ -334,12 +334,7 @@ view_file (char *filename, int fd, unsigned int viewedit, unsigned int del_file,
   gtk_box_set_spacing (GTK_BOX (GTK_DIALOG (dialog)->vbox), 5);
   gtk_widget_realize (dialog);
 
-  if (gftp_icon != NULL)
-    {
-      gdk_window_set_icon (dialog->window, NULL, gftp_icon->pixmap,
-                           gftp_icon->bitmap);
-      gdk_window_set_icon_name (dialog->window, gftp_version);
-    }
+  set_window_icon(GTK_WINDOW(dialog), NULL);
 
   table = gtk_table_new (1, 2, FALSE);
   gtk_box_pack_start (GTK_BOX (GTK_DIALOG (dialog)->vbox), table, TRUE, TRUE, 0);


### PR DESCRIPTION
gftp_graphic->GdkPixmap is deprecated in gtk2

cannot remove it yet.. it's used by GtkCList