### PR TITLE
ssh2 [sftp]: do not disconnect on trivial errors

### DIFF
--- a/lib/gftp.h
+++ b/lib/gftp.h
@@ -191,6 +191,7 @@
 						   returned when a FXP transfer
 						   is requested */
 #define GFTP_ETIMEDOUT		-5		/* Connected timed out */
+#define GFTP_ECANIGNORE         -6              /* Error that can be ignored */
 
 /* Some general settings */
 #define BASE_CONF_DIR		"~/.gftp"

--- a/lib/local.c
+++ b/lib/local.c
@@ -110,7 +110,7 @@ local_chdir (gftp_request * request, const char *directory)
       request->logging_function (gftp_logging_error, request,
                                  _("Could not change local directory to %s: %s\n"),
                                  directory, g_strerror (errno));
-      ret = GFTP_ERETRYABLE;
+      ret = GFTP_ECANIGNORE;
     }
 
   return (ret);
@@ -422,7 +422,7 @@ local_list_files (gftp_request * request)
       request->logging_function (gftp_logging_error, request,
                            _("Could not get local directory listing %s: %s\n"),
                            request->directory, g_strerror (errno));
-      return (GFTP_ERETRYABLE);
+      return (GFTP_ECANIGNORE);
     }
   else
     return (0);

--- a/lib/sshv2.c
+++ b/lib/sshv2.c
@@ -919,8 +919,10 @@ sshv2_read_status_response (gftp_request * request, sshv2_message * message,
 
       sshv2_message_free (message);
 
-      if (num == SSH_FX_PERMISSION_DENIED)
-        return (GFTP_EFATAL);
+      if ( num == SSH_FX_PERMISSION_DENIED 
+        || num == SSH_FX_NO_SUCH_FILE
+        || num == SSH_FX_FAILURE)
+        return (GFTP_ECANIGNORE);
       else
         return (GFTP_ERETRYABLE);
     }
@@ -939,12 +941,12 @@ sshv2_response_return_code (gftp_request * request, sshv2_message * message,
     {
       case SSH_FX_OK:
       case SSH_FX_EOF:
-      case SSH_FX_NO_SUCH_FILE:
-      case SSH_FX_FAILURE:
       case SSH_FX_OP_UNSUPPORTED:
         return (GFTP_ERETRYABLE);
+      case SSH_FX_FAILURE:
+      case SSH_FX_NO_SUCH_FILE:
       case SSH_FX_PERMISSION_DENIED:
-        return (GFTP_EFATAL);
+        return (GFTP_ECANIGNORE);
       default:
         return (sshv2_wrong_response (request, message));
     }

--- a/src/gtk/gftp-gtk.c
+++ b/src/gtk/gftp-gtk.c
@@ -680,15 +680,21 @@ list_doaction (gftp_window_data * wdata)
   if (check_reconnect (wdata) < 0) 
     return;
 
+  success = 0;
   if (S_ISLNK (tempfle->st_mode) || S_ISDIR (tempfle->st_mode))
     {
-      directory = gftp_build_path (wdata->request, wdata->request->directory,
+      if(tempfle->st_mode & S_IXUSR)
+      {
+          directory = gftp_build_path (wdata->request, wdata->request->directory,
                                    tempfle->file, NULL);
-      success = gftpui_run_chdir (wdata, directory);
-      g_free (directory);
+          success = gftpui_run_chdir (wdata, directory);
+          g_free (directory);
+      }else{
+          ftp_log (gftp_logging_error, NULL,
+               _("Directory %s is not listable\n"),
+               tempfle->file);
+      }
     }
-  else
-    success = 0;
 
   if (!S_ISDIR (tempfle->st_mode) && !success)
     {

--- a/src/gtk/transfer.c
+++ b/src/gtk/transfer.c
@@ -34,7 +34,12 @@ ftp_list_files (gftp_window_data * wdata)
   cdata->run_function = gftpui_common_run_ls;
   cdata->dont_refresh = 1;
 
-  gftpui_common_run_callback_function (cdata);
+  if(gftpui_common_run_callback_function (cdata) == GFTP_ECANIGNORE)
+  {
+     g_free(cdata);
+     update_window(wdata);
+     return (1);
+  }
 
   wdata->files = cdata->files;
   g_free (cdata);

--- a/src/uicommon/gftpui.c
+++ b/src/uicommon/gftpui.c
@@ -92,6 +92,9 @@ gftpui_common_run_callback_function (gftpui_callback_data * cdata)
   if (ret == 0 && !cdata->dont_refresh)
     gftpui_refresh (cdata->uidata, !cdata->dont_clear_cache);
 
+  if(ret == GFTP_ECANIGNORE)
+    return GFTP_ECANIGNORE;
+
   return (ret == 0);
 }
 
@@ -1532,7 +1535,7 @@ gftpui_common_transfer_files (gftp_transfer * tdata)
           if (gftp_abort_transfer (tdata->fromreq) != 0)
             gftp_disconnect (tdata->fromreq);
         }
-      else if (ret == GFTP_EFATAL)
+      else if (ret == GFTP_EFATAL || ret == GFTP_ECANIGNORE)
         skipped_files++;
       else if (ret < 0)
         {


### PR DESCRIPTION
Important bugfix

3 fengq patches:
  ignore-permission-error-and-unlistable-directories.patch
  permission-deny-and-file-not-exist-do-not-deserve-di.patch
  treat-SSH_FX_FAILURE-as-a-non-fatal-error.patch

It seems to work fine.. well at least a sftp connection is less buggy

tested with frs.sourceforge.net 22