### PR TITLE
update bookmarks

### DIFF
--- a/docs/sample.gftp/bookmarks
+++ b/docs/sample.gftp/bookmarks
@@ -23,67 +23,47 @@ password=@EMAIL@
 account=
 
 [BSD Sites/OpenBSD]
-hostname=ftp.openbsd.org
+hostname=mirrors.mit.edu
 port=21
 protocol=FTP
-remote directory=/pub
+remote directory=/pub/OpenBSD
 local directory=
 username=anonymous
 password=@EMAIL@
 account=
 
-[Debian Sites/Debian]
-hostname=ftp.debian.org
+[Linux Kernel/Kernel - Mirror Service]
+hostname=mirrorservice.org
 port=21
 protocol=FTP
-remote directory=/debian
+remote directory=/sites/ftp.kernel.org/pub/linux/kernel
 local directory=
 username=anonymous
 password=@EMAIL@
 account=
 
-[Fedora Sites/Fedora]
-hostname=download.fedora.redhat.com
+[Linux Kernel/Kernel - Host Europe]
+hostname=ftp.hosteurope.de
 port=21
 protocol=FTP
-remote directory=/pub/fedora/linux
+remote directory=/mirror/ftp.kernel.org/pub/linux/kernel
 local directory=
 username=anonymous
 password=@EMAIL@
 account=
 
-[General Sites/gFTP]
-hostname=www.gftp.org
+[Linux Kernel/Kernel - Free FR]
+hostname=ftp.free.fr
 port=21
 protocol=FTP
-remote directory=/pub/gftp
-local directory=
-username=anonymous
-password=@EMAIL@
-account=
-
-[General Sites/GNU Archive]
-hostname=prep.ai.mit.edu
-port=21
-protocol=FTP
-remote directory=/pub/gnu
-local directory=
-username=anonymous
-password=@EMAIL@
-account=
-
-[General Sites/Kernel.Org]
-hostname=ftp.kernel.org
-port=21
-protocol=FTP
-remote directory=/
+remote directory=/mirrors/ftp.kernel.org/linux/kernel/
 local directory=
 username=anonymous
 password=@EMAIL@
 account=
 
 [General Sites/Ibiblio]
-hostname=ibiblio.unc.edu
+hostname=distro.ibiblio.org
 port=21
 protocol=FTP
 remote directory=/pub/Linux
@@ -92,18 +72,8 @@ username=anonymous
 password=@EMAIL@
 account=
 
-[General Sites/Micro$~1 =)]
-hostname=ftp.microsoft.com
-port=21
-protocol=FTP
-remote directory=/
-local directory=
-username=anonymous
-password=@EMAIL@
-account=
-
-[General Sites/Mozilla]
-hostname=ftp.mozilla.org
+[General Sites/Nluug]
+hostname=ftp.nluug.nl
 port=21
 protocol=FTP
 remote directory=/pub
@@ -112,141 +82,21 @@ username=anonymous
 password=@EMAIL@
 account=
 
-[General Sites/Rufus]
-hostname=rufus.w3.org
+[General Sites/Mirror Service]
+hostname=mirrorservice.org
 port=21
 protocol=FTP
-remote directory=/
+remote directory=/sites
 local directory=
 username=anonymous
 password=@EMAIL@
 account=
 
-[General Sites/Tux.Org]
-hostname=ftp.tux.org
+[General Sites/GNU Archive]
+hostname=ftp.gnu.org
 port=21
 protocol=FTP
-remote directory=/pub
-local directory=
-username=anonymous
-password=@EMAIL@
-account=
-
-[General Sites/Wcarchive]
-hostname=ftp.cdrom.com
-port=21
-protocol=FTP
-remote directory=/
-local directory=
-username=anonymous
-password=@EMAIL@
-account=
-
-[Mandriva Sites/Community SRPMS (California)]
-hostname=mirrors.usc.edu
-port=21
-protocol=FTP
-remote directory=/pub/linux/distributions/mandrakelinux/devel/community/SRPMS/
-local directory=
-username=anonymous
-password=@EMAIL@
-account=
-
-[Mandriva Sites/Devel iso (California)]
-hostname=mirrors.usc.edu
-port=21
-protocol=FTP
-remote directory=/pub/linux/distributions/mandrakelinux/devel/iso/
-local directory=
-username=anonymous
-password=@EMAIL@
-account=
-
-[Mandriva Sites/Official iso (California)]
-hostname=mirrors.usc.edu
-port=21
-protocol=FTP
-remote directory=/pub/linux/distributions/mandrakelinux/official/iso/
-local directory=
-username=anonymous
-password=@EMAIL@
-account=
-
-[Mandriva Sites/Mandriva Old (California)]
-hostname=mirrors.usc.edu
-port=21
-protocol=FTP
-remote directory=/pub/linux/distributions/mandrakelinux/old/
-local directory=
-username=anonymous
-password=@EMAIL@
-account=
-
-[Mandriva Sites/Community SRPMS (France)]
-hostname=ftp.ciril.fr
-port=21
-protocol=FTP
-remote directory=/pub/linux/mandrakelinux/devel/community/SRPMS/
-local directory=
-username=anonymous
-password=@EMAIL@
-account=
-
-[Mandriva Sites/Devel iso (France)]
-hostname=ftp.ciril.fr
-port=21
-protocol=FTP
-remote directory=/pub/linux/mandrakelinux/devel/iso/
-local directory=
-username=anonymous
-password=@EMAIL@
-account=
-
-[Mandriva Sites/Official iso (France)]
-hostname=ftp.ciril.fr
-port=21
-protocol=FTP
-remote directory=/pub/linux/mandrakelinux/official/iso/
-local directory=
-username=anonymous
-password=@EMAIL@
-account=
-
-[Mandriva Sites/Community SRPMS (Taiwan)]
-hostname=ftp.isu.edu.tw
-port=21
-protocol=FTP
-remote directory=/pub/Linux/Mandrakelinux/devel/community/SRPMS/
-local directory=
-username=anonymous
-password=@EMAIL@
-account=
-
-[Mandriva Sites/Devel iso (Taiwan)]
-hostname=ftp.isu.edu.tw
-port=21
-protocol=FTP
-remote directory=/pub/Linux/Mandrakelinux/devel/iso/
-local directory=
-username=anonymous
-password=@EMAIL@
-account=
-
-[Mandriva Sites/Official iso (Taiwan)]
-hostname=ftp.isu.edu.tw
-port=21
-protocol=FTP
-remote directory=/pub/Linux/Mandrakelinux/official/iso/
-local directory=
-username=anonymous
-password=@EMAIL@
-account=
-
-[Mandriva Sites/Mandriva Old (Taiwan)]
-hostname=ftp.isu.edu.tw
-port=21
-protocol=FTP
-remote directory=/pub/Linux/Mandrakelinux/old/
+remote directory=/pub/gnu
 local directory=
 username=anonymous
 password=@EMAIL@
@@ -254,26 +104,6 @@ account=
 
 [Red Hat Sites/RH Main]
 hostname=ftp.redhat.com
-port=21
-protocol=FTP
-remote directory=/pub
-local directory=
-username=anonymous
-password=@EMAIL@
-account=
-
-[Red Hat Sites/RH Updates]
-hostname=updates.redhat.com
-port=21
-protocol=FTP
-remote directory=/
-local directory=
-username=anonymous
-password=@EMAIL@
-account=
-
-[Red Hat Sites/Fresh RPMS]
-hostname=ftp.freshrpms.net
 port=21
 protocol=FTP
 remote directory=/pub
@@ -292,88 +122,19 @@ username=anonymous
 password=@EMAIL@
 account=
 
-[SuSE Sites/SuSE]
-hostname=ftp.suse.com
+[Debian Sites/Debian]
+hostname=ftp.debian.org
 port=21
 protocol=FTP
-remote directory=/pub/suse/i386
+remote directory=/debian
 local directory=
 username=anonymous
 password=@EMAIL@
 account=
 
-[SuSE Sites/SuSE Contrib]
-hostname=ftp.suse.com
-port=21
-protocol=FTP
-remote directory=/pub/contrib
-local directory=
-username=anonymous
-password=@EMAIL@
-account=
-
-[SuSE Sites/OpenSuSE Update]
-hostname=ftp.hosteurope.de
-port=21
-protocol=FTP
-remote directory=/mirror/ftp.opensuse.org/update
-local directory=
-username=anonymous
-password=@EMAIL@
-account=
-
-[X11 Sites/Gimp]
-hostname=ftp.gimp.org
-port=21
-protocol=FTP
-remote directory=/pub/gimp
-local directory=
-username=anonymous
-password=@EMAIL@
-account=
 
 [X11 Sites/Gnome]
 hostname=ftp.gnome.org
-port=21
-protocol=FTP
-remote directory=/pub
-local directory=
-username=anonymous
-password=@EMAIL@
-account=
-
-[X11 Sites/GTK+]
-hostname=ftp.gtk.org
-port=21
-protocol=FTP
-remote directory=/pub/gtk
-local directory=
-username=anonymous
-password=@EMAIL@
-account=
-
-[X11 Sites/KDE]
-hostname=ftp.kde.org
-port=21
-protocol=FTP
-remote directory=/pub
-local directory=
-username=anonymous
-password=@EMAIL@
-account=
-
-[X11 Sites/Qt]
-hostname=ftp.troll.no
-port=21
-protocol=FTP
-remote directory=/qt/source
-local directory=
-username=anonymous
-password=@EMAIL@
-account=
-
-[X11 Sites/XFree86]
-hostname=ftp.xfree86.org
 port=21
 protocol=FTP
 remote directory=/pub


### PR DESCRIPTION
Many FTP sites no longer exist, including ftp.kernel.org:

https://www.kernel.org/shutting-down-ftp-services.html

Some other ftp sites are unreachable or something (mozilla, debian)
[filezilla can't connect either] but the web version works ok.

Some other ftp sites offer basically empty repositories (suse, rh updates)
or useless repositories (xfree)

I updated a few urls, I also added a few new interesting FTP sites (big mirrors)