### PR TITLE
gtkui: get_image_path(): simplify / print missing icon to stderr..

### DIFF
--- a/src/gtk/gftp-gtk.h
+++ b/src/gtk/gftp-gtk.h
@@ -344,8 +344,7 @@ int progress_timeout 				( gpointer data );
 
 void display_cached_logs			( void );
 
-char * get_image_path 				( char *filename, 
-						  int quit_on_err );
+char * get_image_path 				( char *filename);
 
 void set_window_icon(GtkWindow *window, char *icon_name);
 

--- a/src/gtk/menu-items.c
+++ b/src/gtk/menu-items.c
@@ -425,7 +425,7 @@ about_dialog (gpointer data)
     };
     /* TRANSLATORS: Replace this string with your names, one name per line. */
     gchar * translators = _("Translated by");
-    char * logopath = get_image_path ("gftp-logo.xpm", 0); /* misc-gtk.c */
+    char * logopath = get_image_path ("gftp-logo.xpm"); /* misc-gtk.c */
 
     /* Create and initialize the dialog. */
     GtkWidget * about_dlg = gtk_about_dialog_new();


### PR DESCRIPTION
If gftp can't find icons it shows many errors like this:

(gftp-gtk:10751): GLib-GObject-CRITICAL **: g_object_ref: assertion 'G_IS_OBJECT (object)' failed

Now it shows something more meaningful:

(gftp-gtk:11305): GLib-GObject-CRITICAL **: g_object_ref: assertion 'G_IS_OBJECT (object)' failed
* gftp: /usr/local/share/gftpdoc.xpm not found
* gftp: /usr/share/gftp/doc.xpm not found

The 1st 'not found' line is the --prefix/datadir (default = /usr/local/share/..)
or the env variable GFTP_SHARE_DIR - see lib/misc.c: gftp_get_share_dir ()

The 2nd 'not found' line is the fallback (/usr/s...), this line is omitted if --prefix=/usr