### PR TITLE
[glib 2.32] don't check for gthread / don't call g_thread_init()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -103,8 +103,6 @@ AC_SUBST(GFTP_TEXT)
 GFTP_GTK=""
 PTHREAD_CFLAGS=""
 PTHREAD_LIBS=""
-GTHREAD_CFLAGS=""
-GTHREAD_LIBS=""
 
 PKG_CHECK_MODULES(
   [GLIB], [glib-2.0 >= 2.32.0], found_glib=yes,
@@ -127,7 +125,6 @@ if test "x$enable_gtkport" = "xyes" ; then
   if test "x$enable_gtk2" = "xyes" ; then
     dnl Test for gtk+-2.0
     PKG_CHECK_MODULES([GTK], [gtk+-2.0 >= 2.24.0], GFTP_GTK=gftp-gtk, AC_MSG_ERROR(You have GLIB 2.0 installed but I cannot find GTK+ 2.0. Run configure with --disable-gtk2 or install GTK+ 2.0))
-    PKG_CHECK_MODULES([GTHREAD], gthread-2.0 >=  2.32.0, HAVE_GTHREADS="yes")
   fi
   if test "x$enable_gtk3" = "xyes" ; then
     dnl Test for gtk+-3.0
@@ -152,8 +149,6 @@ if test "x$enable_gtkport" = "xyes" ; then
 fi
 AC_SUBST(PTHREAD_CFLAGS)
 AC_SUBST(PTHREAD_LIBS)
-AC_SUBST(GTHREAD_LIBS)
-AC_SUBST(GTHREAD_CFLAGS)
 AC_SUBST(GFTP_GTK)
 
 SSL_LIBS=""

--- a/src/gtk/Makefile.am
+++ b/src/gtk/Makefile.am
@@ -9,6 +9,6 @@ gftp_gtk_SOURCES = bookmarks.c chmod_dialog.c delete_dialog.c dnd.c \
 
 AM_CPPFLAGS = @GTK_CFLAGS@ @PTHREAD_CFLAGS@
 
-LDADD = ../../lib/libgftp.a ../uicommon/libgftpui.a @GTK_LIBS@ @PTHREAD_LIBS@ @EXTRA_LIBS@ @GTHREAD_LIBS@ @SSL_LIBS@ @LIBINTL@
+LDADD = ../../lib/libgftp.a ../uicommon/libgftpui.a @GTK_LIBS@ @PTHREAD_LIBS@ @EXTRA_LIBS@ @SSL_LIBS@ @LIBINTL@
 
 noinst_HEADERS = gftp-gtk.h

--- a/src/gtk/gftp-gtk.c
+++ b/src/gtk/gftp-gtk.c
@@ -1663,10 +1663,6 @@ main (int argc, char **argv)
   gftpui_common_init (&argc, &argv, ftp_log);
   gftpui_common_child_process_done = 0;
 
-#if !GLIB_CHECK_VERSION(2,31,0)
-  g_thread_init (NULL);
-#endif
-
   gdk_threads_init();
   GDK_THREADS_ENTER ();
   main_thread_id = pthread_self ();


### PR DESCRIPTION
http://hpux.connect.org.uk/hppd/hpux/Gtk/Development/glib2-2.34.3/readme.html

Notes about GLib 2.32
=====================

* It is no longer necessary to use g_thread_init() or to link against
  libgthread.  libglib is now always thread-enabled. Custom thread
  system implementations are no longer supported (including errorcheck
  mutexes).