### PR TITLE
gftp-gtk.c: Only call gtk_window_set_policy on gtk2

### DIFF
--- a/src/gtk/gftp-gtk.c
+++ b/src/gtk/gftp-gtk.c
@@ -1498,7 +1498,9 @@ main (int argc, char **argv)
   gtk_window_set_title (main_window, gftp_version);
   gtk_window_set_wmclass (main_window, "main", "gFTP");
   gtk_widget_set_name (GTK_WIDGET(main_window), gftp_version);
+#if GTK_MAJOR_VERSION==2
   gtk_window_set_policy (main_window, TRUE, TRUE, FALSE);
+#endif
   gtk_widget_realize (GTK_WIDGET(main_window));
 
   set_window_icon(main_window, NULL);


### PR DESCRIPTION
   Only call gtk_window_set_policy on gtk2 builds (gtk1.x api deprecated in gtk2.x)
   The window is resizable by default in gtk3, but if needed, we can call gtk_window_set_resizable which is compatible with gtk2.x and 3.x