### PR TITLE
src/gtk: add gtkcompat.c / gtkcompat.h

### DIFF
--- a/src/gtk/Makefile.am
+++ b/src/gtk/Makefile.am
@@ -2,13 +2,22 @@
 
 bin_PROGRAMS = @GFTP_GTK@
 EXTRA_PROGRAMS = gftp-gtk
-gftp_gtk_SOURCES = bookmarks.c chmod_dialog.c dnd.c \
-                     gftp-gtk.c gtkui.c gtkui_transfer.c menu-items.c \
-                     misc-gtk.c options_dialog.c platform_specific.c \
-                     transfer.c view_dialog.c
+gftp_gtk_SOURCES = bookmarks.c \
+	chmod_dialog.c \
+	dnd.c \
+	gftp-gtk.c \
+	gtkcompat.c \
+	gtkui.c \
+	gtkui_transfer.c \
+	menu-items.c \
+	misc-gtk.c \
+	options_dialog.c \
+	platform_specific.c \
+	transfer.c \
+	view_dialog.c
 
 AM_CPPFLAGS = @GTK_CFLAGS@ @PTHREAD_CFLAGS@
 
 LDADD = ../../lib/libgftp.a ../uicommon/libgftpui.a @GTK_LIBS@ @PTHREAD_LIBS@ @EXTRA_LIBS@ @SSL_LIBS@ @LIBINTL@
 
-noinst_HEADERS = gftp-gtk.h
+noinst_HEADERS = gftp-gtk.h gtkcompat.h

--- a/src/gtk/gftp-gtk.h
+++ b/src/gtk/gftp-gtk.h
@@ -24,6 +24,7 @@
 
 #include "../../lib/gftp.h"
 #include "../uicommon/gftpui.h"
+#include "gtkcompat.h"
 #include <gtk/gtk.h>
 #include <gdk/gdkkeysyms.h>
 #include <pthread.h>

--- a/src/gtk/gtkcompat.c
+++ b/src/gtk/gtkcompat.c
@@ -1,0 +1,102 @@
+/*
+ * GTK COMPAT
+ */
+
+#include "gtkcompat.h"
+
+#if !GTK_CHECK_VERSION (3, 0, 0)
+
+// GTK 2.24 and lower
+
+GtkWidget *
+gtk_box_new (GtkOrientation orientation, gint spacing)
+{
+	// the HOMOGENEOUS property defaults to FALSE
+	// add this to make it TRUE
+	//   gtk_box_set_homogeneous (GTK_BOX(hbox), TRUE);
+	if (orientation == GTK_ORIENTATION_HORIZONTAL) {
+		return gtk_hbox_new (FALSE, spacing);
+	}
+	if (orientation == GTK_ORIENTATION_VERTICAL) {
+		return gtk_vbox_new (FALSE, spacing);
+	}
+	return NULL;
+}
+
+GtkWidget *
+gtk_button_box_new (GtkOrientation orientation)
+{
+	if (orientation == GTK_ORIENTATION_HORIZONTAL) {
+		return gtk_hbutton_box_new ();
+	}
+	if (orientation == GTK_ORIENTATION_VERTICAL) {
+		return gtk_vbutton_box_new ();
+	}
+	return NULL;
+}
+
+GtkWidget *
+gtk_scale_new (GtkOrientation orientation, GtkAdjustment *adjustment)
+{
+	if (orientation == GTK_ORIENTATION_HORIZONTAL) {
+		return gtk_hscale_new (adjustment);
+	}
+	if (orientation == GTK_ORIENTATION_VERTICAL) {
+		return gtk_vscale_new (adjustment);
+	}
+	return NULL;
+}
+
+GtkWidget *
+gtk_scale_new_with_range (GtkOrientation orientation,
+                          gdouble min,
+                          gdouble max,
+                          gdouble step)
+{
+	if (orientation == GTK_ORIENTATION_HORIZONTAL) {
+		return gtk_hscale_new_with_range (min, max, step);
+	}
+	if (orientation == GTK_ORIENTATION_VERTICAL) {
+		return gtk_vscale_new_with_range (min, max, step);
+	}
+	return NULL;
+}
+
+GtkWidget *
+gtk_separator_new (GtkOrientation orientation)
+{
+	if (orientation == GTK_ORIENTATION_HORIZONTAL) {
+		return gtk_hseparator_new ();
+	}
+	if (orientation == GTK_ORIENTATION_VERTICAL) {
+		return gtk_vseparator_new ();
+	}
+	return NULL;
+}
+
+GtkWidget *
+gtk_scrollbar_new (GtkOrientation orientation, GtkAdjustment *adjustment)
+{
+	if (orientation == GTK_ORIENTATION_HORIZONTAL) {
+		return gtk_hscrollbar_new (adjustment);
+	}
+	if (orientation == GTK_ORIENTATION_VERTICAL) {
+		return gtk_vscrollbar_new (adjustment);
+	}
+	return NULL;
+}
+
+GtkWidget *
+gtk_paned_new (GtkOrientation orientation)
+{
+	if (orientation == GTK_ORIENTATION_HORIZONTAL) {
+		return gtk_hpaned_new ();
+	}
+	if (orientation == GTK_ORIENTATION_VERTICAL) {
+		return gtk_vpaned_new ();
+	}
+	return NULL;
+}
+
+#endif
+

--- a/src/gtk/gtkcompat.h
+++ b/src/gtk/gtkcompat.h
@@ -1,0 +1,21 @@
+/*
+ * Z GTK COMPAT
+ */
+
+#ifndef __GTKCOMPAT_H
+#define __GTKCOMPAT_H
+
+#include <gtk/gtk.h>
+#include <stdio.h>
+
+#if !GTK_CHECK_VERSION (3, 0, 0)
+GtkWidget *gtk_box_new (GtkOrientation orientation, gint spacing) ;
+GtkWidget *gtk_button_box_new (GtkOrientation orientation);
+GtkWidget *gtk_scale_new (GtkOrientation orientation, GtkAdjustment *adjustment);
+GtkWidget *gtk_scale_new_with_range (GtkOrientation orientation, gdouble min, gdouble max, gdouble step);
+GtkWidget *gtk_separator_new (GtkOrientation orientation);
+GtkWidget *gtk_scrollbar_new (GtkOrientation orientation, GtkAdjustment *adjustment);
+GtkWidget *gtk_paned_new (GtkOrientation orientation);
+#endif
+
+#endif


### PR DESCRIPTION
It currently defines the following functions:

-   gtk_box_new
-   gtk_button_box_new
-   gtk_scale_new
-   gtk_scale_new_with_range
-   gtk_separator_new
-   gtk_scrollbar_new
-   gtk_paned_new

It makes it easier to update code without adding ifdefs

Example, this
```
   #if GTK_CHECK_VERSION (3, 2, 0)
        hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 4);
   #else //gtk2
        hbox = gtk_hbox_new (FALSE, 4);
   #endif
```
becomes
```
   hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 4);
```