### PR TITLE
src/gtk:  Adapt GTK keypress support to support both gtk2 and gtk3

### DIFF
--- a/src/gtk/gftp-gtk.h
+++ b/src/gtk/gftp-gtk.h
@@ -25,8 +25,6 @@
 #include "../../lib/gftp.h"
 #include "../uicommon/gftpui.h"
 #include "gtkcompat.h"
-#include <gtk/gtk.h>
-#include <gdk/gdkkeysyms.h>
 #include <pthread.h>
 
 #define GFTP_MENU_ITEM_ASCII	1

--- a/src/gtk/gtkcompat.h
+++ b/src/gtk/gtkcompat.h
@@ -6,6 +6,12 @@
 #define __GTKCOMPAT_H
 
 #include <gtk/gtk.h>
+#include <gdk/gdkkeysyms.h>
+
+#if GTK_CHECK_VERSION (3, 0, 0)
+#include <gdk/gdkkeysyms-compat.h>
+#endif
+
 #include <stdio.h>
 
 #if !GTK_CHECK_VERSION (3, 0, 0)


### PR DESCRIPTION
This patch looks and seems right, however I may be tripping over a bug in the Mac GTK/GLIB keyboard handling.

WIth or without this patch, if I hit the DELETE key, it just moves the selection up to the parent in the bookmarks editor.

I would appreciate it if you could verify the functionality works under linux as is with gtk2 and then see if my patch introduces a regression.
