### PR TITLE
gtk: replace references of GdkBitmap and GdkPixmap for GdkPixbuf

### DIFF
--- a/src/gtk/gftp-gtk.h
+++ b/src/gtk/gftp-gtk.h
@@ -87,8 +87,8 @@ typedef struct _gftpui_gtk_thread_data
 typedef struct gftp_graphic_tag
 {
   char * filename;
-  GdkPixmap * pixmap;
-  GdkBitmap * bitmap;
+  GdkPixbuf * pixmap;
+  GdkPixbuf * bitmap;
 } gftp_graphic;
 
 typedef struct gftp_dialog_data_tag
@@ -294,8 +294,8 @@ void gftp_free_pixmap 				( char *filename );
 
 void gftp_get_pixmap 				( GtkWidget * widget, 
 						  char *filename, 
-						  GdkPixmap ** pix,
-						  GdkBitmap ** bitmap );
+						  GdkPixbuf ** pix,
+						  GdkPixbuf ** bitmap );
 
 GdkPixbuf *       gftp_get_pixbuf (char *filename);
 

--- a/src/gtk/misc-gtk.c
+++ b/src/gtk/misc-gtk.c
@@ -404,8 +404,8 @@ gftp_free_pixmap (char *filename)
 
 
 void
-gftp_get_pixmap (GtkWidget * widget, char *filename, GdkPixmap ** pix,
-                 GdkBitmap ** bitmap)
+gftp_get_pixmap (GtkWidget * widget, char *filename, GdkPixbuf ** pix,
+                 GdkPixbuf ** bitmap)
 {
   gftp_graphic * graphic;
 

--- a/src/gtk/transfer.c
+++ b/src/gtk/transfer.c
@@ -505,8 +505,8 @@ cancel_get_trans_password (gftp_transfer * tdata, gftp_dialog_data * ddata)
 static void
 show_transfer (gftp_transfer * tdata)
 {
-  GdkPixmap * closedir_pixmap, * opendir_pixmap;
-  GdkBitmap * closedir_bitmap, * opendir_bitmap;
+  GdkPixbuf * closedir_pixmap, * opendir_pixmap;
+  GdkPixbuf * closedir_bitmap, * opendir_bitmap;
   gftpui_common_curtrans_data * transdata;
   gftp_file * tempfle;
   GList * templist;


### PR DESCRIPTION
I am not sure I understand the code here properly. I tested this on gtk2 and didn't encounter a visual regression with any of the images when doing transfers but perhaps I am failing to follow the logic.

This compiles with no warnings or errors....but my understanding is that it shouldn't work, and that this should be done via Cairo surfaces. Please advise.