### PR TITLE
RFC: gftp-gtk.c: CreateConnectToolbar instead of returning toolbar, return the gtk box itself

### DIFF
--- a/src/gtk/gftp-gtk.c
+++ b/src/gtk/gftp-gtk.c
@@ -733,7 +733,7 @@ CreateConnectToolbar (GtkWidget * parent)
   char *default_protocol, *tempstr;
   int i, j, num;
 
-  toolbar = gtk_handle_box_new ();
+  //toolbar = gtk_handle_box_new ();
 
   box = gtk_hbox_new (FALSE, 4);
   gtk_container_add (GTK_CONTAINER (toolbar), box);
@@ -863,7 +863,8 @@ CreateConnectToolbar (GtkWidget * parent)
 
   //gtk_widget_grab_focus (GTK_WIDGET (hostedit));
 
-  return (toolbar);
+  //return (toolbar);
+  return (box);
 }
 
 


### PR DESCRIPTION
I am not sure if this is a GTK3 regression, or if gtk2 was perhaps more forgiving, (and gtk3 is less so...) but with this patch I am much closer to having the full UI function as in the gtk2 case. Please see the attached screenshots for your review.

GTK3
<img width="1335" alt="gtk3" src="https://user-images.githubusercontent.com/48265/88142231-fba49400-cba9-11ea-9f8e-9405c84b84c0.png">

GTK2
<img width="1285" alt="gtk2" src="https://user-images.githubusercontent.com/48265/88142243-03643880-cbaa-11ea-8315-8f37aa07c4b0.png">
