### PR TITLE
src/gtk: Replace calls of gtk_window_set_wmclass to gtk_window_set_role

### DIFF
--- a/src/gtk/bookmarks.c
+++ b/src/gtk/bookmarks.c
@@ -880,8 +880,7 @@ edit_entry_dlg (gpointer data)
               GTK_STOCK_SAVE,   GTK_RESPONSE_OK,
               NULL);
 
-  gtk_window_set_wmclass (GTK_WINDOW (bm_dialog), "Edit Bookmark Entry",
-                          "gFTP");
+  gtk_window_set_role (GTK_WINDOW (bm_dialog), "Edit Bookmark Entry");
   gtk_window_set_position (GTK_WINDOW (bm_dialog), GTK_WIN_POS_MOUSE);
   gtk_widget_realize (bm_dialog);
 

--- a/src/gtk/chmod_dialog.c
+++ b/src/gtk/chmod_dialog.c
@@ -132,7 +132,7 @@ chmod_dialog (gpointer data)
                                         GTK_RESPONSE_OK,
                                         NULL);
 
-  gtk_window_set_wmclass (GTK_WINDOW(dialog), "Chmod", "gFTP");
+  gtk_window_set_role (GTK_WINDOW(dialog), "Chmod");
   gtk_window_set_position (GTK_WINDOW (dialog), GTK_WIN_POS_MOUSE);
 
   main_vbox = gtk_dialog_get_content_area (GTK_DIALOG (dialog));

--- a/src/gtk/gftp-gtk.c
+++ b/src/gtk/gftp-gtk.c
@@ -1496,7 +1496,7 @@ main (int argc, char **argv)
   g_signal_connect (G_OBJECT (main_window), "destroy",
 		      G_CALLBACK (_gftp_force_close), NULL);
   gtk_window_set_title (main_window, gftp_version);
-  gtk_window_set_wmclass (main_window, "main", "gFTP");
+  gtk_window_set_role (main_window, "main");
   gtk_widget_set_name (GTK_WIDGET(main_window), gftp_version);
 #if GTK_MAJOR_VERSION==2
   gtk_window_set_policy (main_window, TRUE, TRUE, FALSE);

--- a/src/gtk/gtkui_transfer.c
+++ b/src/gtk/gtkui_transfer.c
@@ -234,7 +234,7 @@ gftpui_ask_transfer (gftp_transfer * tdata)
                                         GTK_RESPONSE_OK,
                                         NULL);
 
-  gtk_window_set_wmclass (GTK_WINDOW(dialog), "transfer", "gFTP");
+  gtk_window_set_role (GTK_WINDOW(dialog), "transfer");
   gtk_window_set_position (GTK_WINDOW (dialog), GTK_WIN_POS_MOUSE);
 
   main_vbox = gtk_dialog_get_content_area (GTK_DIALOG (dialog));

--- a/src/gtk/misc-gtk.c
+++ b/src/gtk/misc-gtk.c
@@ -689,7 +689,7 @@ MakeEditDialog (char *diagtxt, char *infotxt, char *deftext, int passwd_item,
 
   gtk_container_set_border_width (GTK_CONTAINER (dialog), 10);
   gtk_box_set_spacing (GTK_BOX (vbox), 5);
-  gtk_window_set_wmclass (GTK_WINDOW(dialog), "edit", "gFTP");
+  gtk_window_set_role (GTK_WINDOW(dialog), "edit");
   gtk_window_set_position (GTK_WINDOW (dialog), GTK_WIN_POS_MOUSE);
   gtk_widget_set_size_request (dialog, 380, -1);
   gtk_grab_add (dialog);
@@ -751,7 +751,7 @@ MakeYesNoDialog (char *diagtxt, char *infotxt,
   gtk_window_set_title (GTK_WINDOW (dialog), diagtxt);
   set_window_icon(GTK_WINDOW(dialog), NULL);
   gtk_window_set_position (GTK_WINDOW (dialog), GTK_WIN_POS_MOUSE);
-  gtk_window_set_wmclass (GTK_WINDOW(dialog), "yndiag", "gFTP");
+  gtk_window_set_role (GTK_WINDOW(dialog), "yndiag");
   gtk_grab_add (dialog);
 
   ddata->dialog = dialog;
@@ -806,7 +806,7 @@ update_directory_download_progress (gftp_transfer * transfer)
       gtk_window_set_title (GTK_WINDOW (dialog),
 			    _("Getting directory listings"));
       gtk_window_set_position (GTK_WINDOW (dialog), GTK_WIN_POS_MOUSE);
-      gtk_window_set_wmclass (GTK_WINDOW(dialog), "dirlist", "gFTP");
+      gtk_window_set_role (GTK_WINDOW(dialog), "dirlist");
 
       vbox = gtk_vbox_new (FALSE, 5);
       gtk_container_set_border_width (GTK_CONTAINER (vbox), 10);

--- a/src/gtk/options_dialog.c
+++ b/src/gtk/options_dialog.c
@@ -889,7 +889,7 @@ add_proxy_host (GtkWidget * widget, gpointer data)
   main_vbox = gtk_dialog_get_content_area (GTK_DIALOG (dialog));
 
   gtk_box_set_spacing (GTK_BOX (main_vbox), 5);
-  gtk_window_set_wmclass (GTK_WINDOW(dialog), "hostinfo", "Gftp");
+  gtk_window_set_role (GTK_WINDOW(dialog), "hostinfo");
   gtk_window_set_position (GTK_WINDOW (dialog), GTK_WIN_POS_MOUSE);
 
   vbox = gtk_vbox_new (FALSE, 6);
@@ -1224,8 +1224,7 @@ options_dialog (gpointer data)
   gtk_window_set_resizable (GTK_WINDOW (gftp_option_data->dialog), FALSE);
   main_vbox = gtk_dialog_get_content_area (GTK_DIALOG (gftp_option_data->dialog));
 
-  gtk_window_set_wmclass (GTK_WINDOW(gftp_option_data->dialog),
-                          "options", "gFTP");
+  gtk_window_set_role (GTK_WINDOW(gftp_option_data->dialog), "options");
   gtk_window_set_position (GTK_WINDOW (gftp_option_data->dialog),
                            GTK_WIN_POS_MOUSE);
 

--- a/src/gtk/view_dialog.c
+++ b/src/gtk/view_dialog.c
@@ -327,7 +327,7 @@ view_file (char *filename, int fd, unsigned int viewedit, unsigned int del_file,
                                         GTK_RESPONSE_CLOSE,
                                         NULL);
 
-  gtk_window_set_wmclass (GTK_WINDOW(dialog), "fileview", "gFTP");
+  gtk_window_set_role (GTK_WINDOW(dialog), "fileview");
 
   main_vbox = gtk_dialog_get_content_area (GTK_DIALOG (dialog));
   gtk_container_set_border_width (GTK_CONTAINER (main_vbox), 10);


### PR DESCRIPTION
According to the documentation:

Don't use this function. It sets the X Window System "class" and "name" hints for a window. According to the ICCCM, you should always set these to the same value for all windows in an application, and GTK+ sets them to that value by default, so calling this function is sort of pointless. However, you may want to call gtk_window_set_role() on each window in your application, for the benefit of the session manager. Setting the role allows the window manager to restore window positions when loading a saved session.

This has the side-effect of making the application more compatible with non-Xlib based platforms