### PR TITLE
Fixes to desktop file

### DIFF
--- a/docs/gftp.desktop
+++ b/docs/gftp.desktop
@@ -8,3 +8,4 @@ Terminal=false
 Type=Application
 Icon=gftp.png
 Categories=Network;
+Keywords=ftp;network;transfer;file;

--- a/docs/gftp.desktop
+++ b/docs/gftp.desktop
@@ -1,5 +1,4 @@
 [Desktop Entry]
-Encoding=UTF-8
 Name=gFTP
 Comment=Download and upload files using multiple file transfer protocols
 Comment[fr]=Télécharge des fichiers en utilisant le protocole FTP


### PR DESCRIPTION
Two warnings from lintian:

```
I: gftp-gtk: desktop-entry-contains-encoding-key usr/share/applications/gftp.desktop:2 Encoding
N: 
N:    The Encoding key is now deprecated by the FreeDesktop standard and all
N:    strings are required to be encoded in UTF-8. This desktop entry
N:    explicitly specifies an Encoding of UTF-8, which is harmless but no
N:    longer necessary.
N:    
N:    The desktop-file-validate tool in the desktop-file-utils package is
N:    useful for checking the syntax of desktop entries.
N:    
N:    Refer to
N:    https://specifications.freedesktop.org/desktop-entry-spec/latest/apc.html
N:    for details.
N:    
N:    Severity: info
N:    
N:    Check: menu-format
N: 
I: gftp-gtk: desktop-entry-lacks-keywords-entry usr/share/applications/gftp.desktop
N: 
N:    This .desktop file does either not contain a "Keywords" entry or it does
N:    not contain any keywords not already present in the "Name" or
N:    "GenericName" entries.
N:    
N:    .desktop files are organized in key/value pairs (similar to .ini files).
N:    "Keywords" is the name of the entry/key in the .desktop file containing
N:    keywords relevant for this .desktop file.
N:    
N:    The desktop-file-validate tool in the desktop-file-utils package is
N:    useful for checking the syntax of desktop entries.
N:    
N:    Refer to
N:    https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html,
N:    https://bugs.debian.org/693918, and
N:    https://wiki.gnome.org/Initiatives/GnomeGoals/DesktopFileKeywords for
N:    details.
N:    
N:    Severity: info
N:    
N:    Check: menu-format
N: 
```

These two commits fixes those.