### PR TITLE
Fix format not a string literal and no format arguments in gtk_message_dialog_new

### DIFF
--- a/src/gtk/bookmarks.c
+++ b/src/gtk/bookmarks.c
@@ -361,7 +361,7 @@ do_make_new (gpointer data, gftp_dialog_data * ddata)
                                  GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
                                  GTK_MESSAGE_ERROR,
                                  GTK_BUTTONS_OK,
-                                 error);
+                                 "%s", error);
      gtk_dialog_run (GTK_DIALOG (m));
      gtk_widget_destroy (m);
      return;


### PR DESCRIPTION
Debian handles some warnings as errors, and thus this is a build failure.

```
bookmarks.c:364:34: error: format not a string literal and no format arguments [-Werror=format-security]
  364 |                                  error);
      |                                  ^~~~~
```