### PR TITLE
Fix bug:lib/pty.c:add check to GNU Hurd since it also haven't a strop…

### DIFF
--- a/lib/pty.c
+++ b/lib/pty.c
@@ -60,7 +60,7 @@ _gftp_ptys_open (int fdm, int fds, char *pts_name)
 
 #elif HAVE_GRANTPT
 
-#if !(defined(__FreeBSD__) || defined(__NetBSD__) || defined(__APPLE__) || defined(__linux__))
+#if !(defined(__FreeBSD__) || defined(__NetBSD__) || defined(__APPLE__) || defined(__linux__) || defined(__GNU__))
 #include <stropts.h>
 #endif
 


### PR DESCRIPTION
I have already report this bug to the debian bug tracking system,  debian-hurd and bug-hurd. 
With their advises, I decide to block the use of `stropts.h` under the GNU Hurd.

https://github.com/masneyb/gftp/issues/110