### PR TITLE
Stop installing app icon in pixmaps location

### DIFF
--- a/icons/Makefile.am
+++ b/icons/Makefile.am
@@ -14,11 +14,8 @@ icon4_DATA = 48x48/gftp.png
 icon5dir = $(datadir)/icons/hicolor/scalable/apps
 icon5_DATA = scalable/gftp.svg
 
-icon6dir = $(datadir)/pixmaps
-icon6_DATA = 48x48/gftp.png
-
 icon7dir = $(datadir)/gftp
 icon7_DATA = 48x48/gftp.png
 
 EXTRA_DIST = $(icon1_DATA) $(icon2_DATA) $(icon3_DATA) \
-             $(icon4_DATA) $(icon5_DATA) $(icon6_DATA) $(icon7_DATA)
+             $(icon4_DATA) $(icon5_DATA) $(icon7_DATA)


### PR DESCRIPTION
The `/usr/share/pixmaps` location is considered a legacy location for
application icons; since the application icons are already installed in
the global XDG hicolor theme, then simply stop installing the 48px one
in the legacy pixmaps location.