### PR TITLE
Address recent regression in macOS build from recent build system transition

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -27,7 +27,8 @@ libgftp = static_library(
     c_args: [
         f'-DSHARE_DIR="@datadir@/gftp"',
 	    f'-DLOCALE_DIR="@datadir@/locale"',
-        f'-DDOC_DIR="@docdir@"'
+        f'-DDOC_DIR="@docdir@"',
+        '-DHAVE_GRANTPT'  # Enable Unix98 PTY support for macOS
     ],
     dependencies: [glib, pthread, ssl],
     install: false


### PR DESCRIPTION
Changelog:
 Address failures with recent macOS builds

  1. Unix98 PTY (lines 26-85) - Uses /dev/ptmx with grantpt() - This is what macOS needs
  2. openpty() (lines 87-125) - Alternative modern method
  3. BSD fallback (lines 127+) - Old /dev/ptyXY style - This is what's being used (doesn't work on macOS)

⏺ The meson build doesn't check for HAVE_GRANTPT or HAVE_OPENPTY, so the code falls back to the old BSD pty method.